### PR TITLE
Feat: add dedicated cron deployment

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 0.2.9
+version: 0.3.0
 appVersion: "16.0"
 sources:
   - https://github.com/odoo/odoo

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -20,3 +20,8 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+{{- if and .Values.cron.enabled (or .Values.existingSecret.enabled .Values.externalsecrets.enabled) }}
+
+WARNING: cron.enabled=true but you are using an externally-managed secret.
+Make sure your odoo.conf contains "max_cron_threads = 0" to disable cron on the main instance.
+{{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.cron.enabled (or .Values.existingSecret.enabled .Values.externalsecrets.enabled) }}
+{{- fail "cron.enabled=true requires max_cron_threads = 0 in your externally-managed odoo.conf. The chart cannot enforce this when existingSecret.enabled or externalsecrets.enabled is true. Set it manually in your secret and set cron.enabled=false to suppress this error." }}
+{{- end }}
 {{- if and (not .Values.existingSecret.enabled) (not .Values.externalsecrets.enabled) }}
 apiVersion: v1
 kind: Secret

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -59,4 +59,9 @@ stringData:
     load_language = {{ .Values.odoo.load_language }}
     log_level = {{ .Values.odoo.log_level }}
     log_handler = {{ .Values.odoo.log_handler }}
+    {{- if .Values.cron.enabled }}
+    max_cron_threads = 0
+    {{- else }}
+    max_cron_threads = {{ .Values.odoo.max_cron_threads | int }}
+    {{- end }}
 {{- end }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,6 +1,3 @@
-{{- if and .Values.cron.enabled (or .Values.existingSecret.enabled .Values.externalsecrets.enabled) }}
-{{- fail "cron.enabled=true requires max_cron_threads = 0 in your externally-managed odoo.conf. The chart cannot enforce this when existingSecret.enabled or externalsecrets.enabled is true. Set it manually in your secret and set cron.enabled=false to suppress this error." }}
-{{- end }}
 {{- if and (not .Values.existingSecret.enabled) (not .Values.externalsecrets.enabled) }}
 apiVersion: v1
 kind: Secret

--- a/test/local.yaml
+++ b/test/local.yaml
@@ -89,8 +89,28 @@ odoo:
   db_maxconn: 64
   db_replica_host: ""
   db_replica_port: 5432
+  max_cron_threads: 2
   log_level: info
   log_handler: ":INFO"
+
+cron:
+  enabled: false
+  replicaCount: 1
+  strategy: Recreate
+  max_cron_threads: 2
+  workers: 2
+  resources: {}
+  extraEnv: []
+  extraEnvFrom: []
+  livenessProbe:
+    httpGet:
+      port: odoo-http
+      path: /web/health
+    initialDelaySeconds: 120
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
 
 # Use an existing secret for the Odoo configuration instead of generating one
 existingSecret:

--- a/values.yaml
+++ b/values.yaml
@@ -96,8 +96,29 @@ odoo:
   db_maxconn: 64
   db_replica_host: ""
   db_replica_port: 5432
+  max_cron_threads: 2
   log_level: info
   log_handler: ":INFO"
+
+cron:
+  enabled: false
+  replicaCount: 1
+  # Recreate prevents two cron instances running simultaneously during updates
+  strategy: Recreate
+  max_cron_threads: 2
+  workers: 2
+  resources: {}
+  extraEnv: []
+  extraEnvFrom: []
+  livenessProbe:
+    httpGet:
+      port: odoo-http
+      path: /web/health
+    initialDelaySeconds: 120
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
 
 # Use an existing secret for the Odoo configuration instead of generating one
 existingSecret:

--- a/values.yaml
+++ b/values.yaml
@@ -96,6 +96,7 @@ odoo:
   db_maxconn: 64
   db_replica_host: ""
   db_replica_port: 5432
+  # Number of cron threads on the main Odoo instance (set to 0 automatically when cron.enabled is true)
   max_cron_threads: 2
   log_level: info
   log_handler: ":INFO"
@@ -105,6 +106,7 @@ cron:
   replicaCount: 1
   # Recreate prevents two cron instances running simultaneously during updates
   strategy: Recreate
+  # Number of cron threads on the dedicated cron deployment
   max_cron_threads: 2
   workers: 2
   resources: {}


### PR DESCRIPTION
  # Summary                                                   

  Adds opt-in support for a dedicated Odoo cron instance, following the Odoo deployment documentation.                                                          
   
  When enabled, scheduled actions are offloaded to a separate deployment, freeing the main Odoo workers from cron execution.                                    
                                                            
  # Changes                                                                                                                                                       
                                                            
  - New templates/cron-deployment.yaml — dedicated Odoo deployment running with --max-cron-threads and --workers CLI overrides, using the same odoo.conf secret 
  as the main instance
  - New templates/cron-service.yaml — ClusterIP service exposing port 8069 for the cron pod                                                                     
  - When cron.enabled: true, max_cron_threads = 0 is injected into odoo.conf to disable cron on the main instance                                               
  - New odoo.max_cron_threads value (default: 2) controls cron threads when no dedicated cron deployment is used                                                
  - Cron deployment is disabled by default (cron.enabled: false)                                                                                                
  - Bump chart to 0.3.0                                                                                                                                         
                                                                                                                                                                
  # Configuration                                             
  
  ```yaml                                                                                                                                                           
  cron:                                                     
    enabled: true
    replicaCount: 1
    strategy: Recreate  # prevents two cron instances running simultaneously
    max_cron_threads: 2                                                                                                                                         
    workers: 2                                                                                                                                                  
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional cron worker deployment configuration with controls for enabling/disabling, replica scaling, concurrency limits, custom resource allocation, environment variables, and liveness health monitoring for background task management.

* **Chores**
  * Chart version updated to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->