### PR TITLE
[FIX] null startupProbe, cron checksums, HPA API version, and component label

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "16.0"
 sources:
   - https://github.com/odoo/odoo

--- a/templates/cron-deployment.yaml
+++ b/templates/cron-deployment.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.externalsecrets.enabled }}
         checksum/secret: {{ include (print $.Template.BasePath "/externalsecrets.yaml") . | sha256sum }}
         {{- else }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       {{- end }}
       labels:
         {{- include "..selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
     spec:
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
@@ -94,8 +95,10 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.startupProbe }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
       volumes:
         - name: {{ include "..fullname" . }}-nginx-conf
           configMap:

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "..fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
- Remove unconditional startupProbe rendering that produced invalid null YAML when .Values.startupProbe is not set
- Add checksum/config annotation to cron deployment so pods restart on configmap changes (was already present on main deployment)
- Upgrade HPA from deprecated autoscaling/v2beta1 to stable autoscaling/v2 and update metric target format accordingly
- Add app.kubernetes.io/component: server label to main deployment pod template for consistency with cron deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Helm chart version to 0.3.1
  * Enhanced Kubernetes HorizontalPodAutoscaler compatibility with current API standards and improved metric definitions
  * Strengthened deployment reliability with configuration checksums and refined startup probe handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->