### PR TITLE
[IMP] Extract odoo.conf generation to shared template helper (closes #7)

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -60,3 +60,55 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate odoo.conf content.
+Call with dict: "Values" .Values "dbPassword" <password> "adminPasswd" <passwd>
+Sensitive values are passed as parameters so both secrets.yaml and
+externalsecrets.yaml can share a single source of truth.
+*/}}
+{{- define "..odooConf" -}}
+[options]
+proxy_mode = {{ .Values.odoo.proxy_mode }}
+{{- if .Values.odoo.addons_path }}
+addons_path = {{ .Values.odoo.addons_path }}
+{{- end }}
+server_wide_modules = {{ .Values.odoo.server_wide_modules }}
+data_dir = /var/lib/odoo
+workers = {{ .Values.odoo.workers | int }}
+limit_memory_soft = {{ .Values.odoo.limit_memory_soft | int }}
+limit_memory_hard = {{ .Values.odoo.limit_memory_hard | int }}
+limit_time_cpu = {{ .Values.odoo.limit_time_cpu | int }}
+limit_time_real = {{ .Values.odoo.limit_time_real | int }}
+limit_time_real_cron = {{ .Values.odoo.limit_time_real_cron | int }}
+limit_request = {{ .Values.odoo.limit_request | int }}
+{{- if .Values.odoo.dbfilter }}
+dbfilter = {{ .Values.odoo.dbfilter }}
+{{- end }}
+db_host = {{ .Values.postgresql.host }}
+{{- if .Values.odoo.db_name }}
+db_name = {{ .Values.postgresql.auth.database }}
+{{- else }}
+db_name = False
+{{- end }}
+db_port = {{ .Values.postgresql.port }}
+db_user = {{ .Values.postgresql.auth.username }}
+db_password = {{ .dbPassword }}
+db_maxconn = {{ .Values.odoo.db_maxconn | int }}
+{{- if .Values.odoo.db_replica_host }}
+db_replica_host = {{ .Values.odoo.db_replica_host }}
+db_replica_port = {{ .Values.odoo.db_replica_port | int }}
+{{- end }}
+without_demo = {{ .Values.odoo.without_demo }}
+admin_passwd = {{ .adminPasswd }}
+list_db = {{ .Values.odoo.list_db }}
+smtp_server = {{ .Values.odoo.smtp_server }}
+load_language = {{ .Values.odoo.load_language }}
+log_level = {{ .Values.odoo.log_level }}
+log_handler = {{ .Values.odoo.log_handler }}
+{{- if .Values.cron.enabled }}
+max_cron_threads = 0
+{{- else }}
+max_cron_threads = {{ .Values.odoo.max_cron_threads | int }}
+{{- end }}
+{{- end }}

--- a/templates/externalsecrets.yaml
+++ b/templates/externalsecrets.yaml
@@ -39,40 +39,7 @@ spec:
         labels: {}
       data:
         odoo.conf: |
-          [options]
-          proxy_mode = {{ .Values.odoo.proxy_mode }}
-          {{- if .Values.odoo.addons_path }}
-          addons_path = {{ .Values.odoo.addons_path }}
-          {{- end }}
-          server_wide_modules = {{ .Values.odoo.server_wide_modules }}
-          data_dir = /var/lib/odoo
-          workers = {{ .Values.odoo.workers | int }}
-          limit_memory_soft = {{ .Values.odoo.limit_memory_soft | int }}
-          limit_memory_hard = {{ .Values.odoo.limit_memory_hard | int }}
-          limit_time_cpu = {{ .Values.odoo.limit_time_cpu | int }}
-          limit_time_real = {{ .Values.odoo.limit_time_real | int }}
-          limit_time_real_cron = {{ .Values.odoo.limit_time_real_cron | int }}
-          limit_request = {{ .Values.odoo.limit_request | int }}
-          {{- if .Values.odoo.dbfilter }}
-          dbfilter = {{ .Values.odoo.dbfilter }}
-          {{- end }}
-          db_host = {{ .Values.postgresql.host }}
-          {{- if .Values.odoo.db_name }}
-          db_name = {{ .Values.postgresql.auth.database }}
-          {{- else }}
-          db_name = False
-          {{- end }}
-          db_port = {{ .Values.postgresql.port }}
-          db_user = {{ .Values.postgresql.auth.username }}
-          db_password = {{ `{{ .postgresqlPassword }}` }}
-          db_maxconn = {{ .Values.odoo.db_maxconn }}
-          without_demo = {{ .Values.odoo.without_demo }}
-          admin_passwd = {{ `{{ .odooAdminPasswd }}` }}
-          list_db = {{ .Values.odoo.list_db }}
-          smtp_server = {{ .Values.odoo.smtp_server }}
-          load_language = {{ .Values.odoo.load_language }}
-          log_level = {{ .Values.odoo.log_level }}
-          log_handler = {{ .Values.odoo.log_handler }}
+{{ include "..odooConf" (dict "Values" .Values "dbPassword" "{{ .postgresqlPassword }}" "adminPasswd" "{{ .odooAdminPasswd }}") | indent 10 }}
   data:
   - secretKey: postgresqlPassword
     remoteRef:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -21,47 +21,5 @@ metadata:
 type: Opaque
 stringData:
   odoo.conf: |
-    [options]
-    proxy_mode = {{ .Values.odoo.proxy_mode }}
-    {{- if .Values.odoo.addons_path }}
-    addons_path = {{ .Values.odoo.addons_path }}
-    {{- end }}
-    server_wide_modules = {{ .Values.odoo.server_wide_modules }}
-    data_dir = /var/lib/odoo
-    workers = {{ .Values.odoo.workers | int }}
-    limit_memory_soft = {{ .Values.odoo.limit_memory_soft | int }}
-    limit_memory_hard = {{ .Values.odoo.limit_memory_hard | int }}
-    limit_time_cpu = {{ .Values.odoo.limit_time_cpu | int }}
-    limit_time_real = {{ .Values.odoo.limit_time_real | int }}
-    limit_time_real_cron = {{ .Values.odoo.limit_time_real_cron | int }}
-    limit_request = {{ .Values.odoo.limit_request | int }}
-    {{- if .Values.odoo.dbfilter }}
-    dbfilter = {{ .Values.odoo.dbfilter }}
-    {{- end }}
-    db_host = {{ .Values.postgresql.host }}
-    {{- if .Values.odoo.db_name }}
-    db_name = {{ .Values.postgresql.auth.database }}
-    {{- else }}
-    db_name = False
-    {{- end }}
-    db_port = {{ .Values.postgresql.port }}
-    db_user = {{ .Values.postgresql.auth.username }}
-    db_password = {{ .Values.postgresql.auth.password }}
-    db_maxconn = {{ .Values.odoo.db_maxconn }}
-    {{- if .Values.odoo.db_replica_host }}
-    db_replica_host = {{ .Values.odoo.db_replica_host }}
-    db_replica_port = {{ .Values.odoo.db_replica_port | int }}
-    {{- end }}
-    without_demo = {{ .Values.odoo.without_demo }}
-    admin_passwd = {{ .Values.odoo.admin_passwd }}
-    list_db = {{ .Values.odoo.list_db }}
-    smtp_server = {{ .Values.odoo.smtp_server }}
-    load_language = {{ .Values.odoo.load_language }}
-    log_level = {{ .Values.odoo.log_level }}
-    log_handler = {{ .Values.odoo.log_handler }}
-    {{- if .Values.cron.enabled }}
-    max_cron_threads = 0
-    {{- else }}
-    max_cron_threads = {{ .Values.odoo.max_cron_threads | int }}
-    {{- end }}
+{{ include "..odooConf" (dict "Values" .Values "dbPassword" .Values.postgresql.auth.password "adminPasswd" .Values.odoo.admin_passwd) | indent 4 }}
 {{- end }}


### PR DESCRIPTION
## Summary

  - Extract `odoo.conf` generation into a shared named template `"..odooConf"`
    in `templates/_helpers.tpl`, called from both `secrets.yaml` and
    `externalsecrets.yaml` (closes #7)
  - Sensitive values (`db_password`, `admin_passwd`) are passed as parameters
    so each backend supplies what it needs: literal values for the default
    secret path, operator-evaluated placeholders (`{{ .postgresqlPassword }}`,
    `{{ .odooAdminPasswd }}`) for the external-secrets path
  - Fixes silent divergence in the externalsecrets path which was missing
    `db_replica_host`/`db_replica_port` and `max_cron_threads`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved organization of Odoo configuration management within Helm chart templates through consolidation of configuration logic into a shared template helper, enhancing maintainability and reducing code duplication across multiple configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->