### PR TITLE
[IMP] Add validation guard for mutually exclusive secret modes (close…

### DIFF
--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.existingSecret.enabled .Values.externalsecrets.enabled }}
+{{- fail "existingSecret and externalsecrets cannot both be enabled. Choose one secret backend." }}
+{{- end }}
 {{- if and (not .Values.existingSecret.enabled) (not .Values.externalsecrets.enabled) }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
  ## Summary                                                                                                                                   
                                                                                                                                               
  - Add a `{{- fail }}` guard at the top of `templates/secrets.yaml` to                                                                        
    prevent enabling `existingSecret` and `externalsecrets` simultaneously                                                                     
    (closes #10)                                                                                                                               
  - Fails fast with a clear error message during `helm template` /                                                                             
    `helm install` / `helm upgrade` instead of silently rendering broken                                                                       
    manifests                                                                                                                                  
  - All three valid configurations are unaffected: generated secrets                                                                           
    (default), `existingSecret.enabled: true` alone, and                                                                                       
    `externalsecrets.enabled: true` alone 