### PR TITLE
[FIX] Add /healthz endpoint to Nginx to avoid Odoo log pollution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ When `maintenance.enabled: true`, the chart:
 
 ### Health Checks
 
-Both liveness and readiness probes hit `/web/health` on the Odoo HTTP port. Liveness has a 120s initial delay; readiness has 30s.
+Both liveness and readiness probes for Odoo hit `/web/health` on the Odoo HTTP port. Liveness has a 120s initial delay; readiness has 30s. The Nginx sidecar probes hit `/healthz` on port 80, which returns 200 directly without proxying to Odoo.
 
 ### PostgreSQL
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -24,7 +24,12 @@ data:
       proxy_set_header X-Forwarded-SSL on;
       proxy_set_header X-Forwarded-Protocol ssl;
       proxy_set_header X-Forwarded-Proto https;
-    
+
+      location = /healthz {
+        access_log off;
+        return 200 "ok";
+      }
+
       location /websocket {
         proxy_pass http://odoochat;
         proxy_set_header Upgrade $http_upgrade;

--- a/test/local.yaml
+++ b/test/local.yaml
@@ -31,13 +31,13 @@ nginx:
   resources: {}
   livenessProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: 80
     initialDelaySeconds: 10
     periodSeconds: 30
   readinessProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: 80
     initialDelaySeconds: 5
     periodSeconds: 10

--- a/values.yaml
+++ b/values.yaml
@@ -43,13 +43,13 @@ nginx:
   #   memory: 128Mi
   livenessProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: 80
     initialDelaySeconds: 10
     periodSeconds: 30
   readinessProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: 80
     initialDelaySeconds: 5
     periodSeconds: 10


### PR DESCRIPTION
 ## Summary

   - Add a dedicated `location = /healthz` endpoint in the Nginx sidecar config that returns `200` directly without proxying to Odoo
   - Update Nginx liveness/readiness probe paths from `/` to `/healthz`
   - Bump chart version to `0.3.3`

   ## Problem

   Nginx probe requests to `/` on port 80 were proxied to Odoo (8069), triggering a redirect chain:

   ```
   GET /              → 303 → /odoo
   GET /odoo          → 303 → /web/login
   GET /web/login     → 200
   ```

   This generated **3 log entries per probe hit** in the Odoo container from `kube-probe/1.30` (~21 junk lines/minute), making it harder to spot real issues in logs. The Odoo container already has its own probes hitting `/web/health`
   directly on port 8069, so the proxy-through was redundant.

   ## Solution

   A new Nginx `location = /healthz` block returns `200 "ok"` immediately with `access_log off`, so:
   - No traffic is proxied to Odoo for health checks
   - No Nginx access log noise either
   - Kubernetes only checks the HTTP status code, so the simple response is sufficient

   ## Files changed

   | File | Change |
   |------|--------|
   | `templates/configmap.yaml` | Add `location = /healthz` block |
   | `values.yaml` | Probe paths `/` → `/healthz` |
   | `test/local.yaml` | Probe paths `/` → `/healthz` |
   | `Chart.yaml` | Version `0.3.2` → `0.3.3` |
   | `CLAUDE.md` | Document Nginx `/healthz` in Health Checks section |

   ## Backwards compatibility

   Users who override `nginx.livenessProbe` or `nginx.readinessProbe` in their values files are unaffected — their overrides continue to work. The ConfigMap checksum annotation will trigger a pod restart on upgrade, which is expected
   since Nginx needs the new config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated health check documentation to clarify Odoo and Nginx sidecar probe configurations.

* **Chores**
  * Updated Helm chart version to 0.3.3.
  * Modified Nginx health check endpoint path from `/` to `/healthz` across configurations.
  * Added dedicated health-check endpoint for Nginx sidecar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->