### PR TITLE
bump gha to v7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Helm Release
-        uses: IMIO/gha/helm-release-notify@v6
+        uses: IMIO/gha/helm-release-notify@v7
         with:
           TARGET_DIR: odoo
           MATTERMOST_WEBHOOK_URL: ${{ secrets.COMMON_MATTERMOST_WEBHOOK_URL }}

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lint and Test Charts
-        uses: IMIO/gha/helm-test-notify@v6
+        uses: IMIO/gha/helm-test-notify@v7
         with:
           HELM_RELEASE: odoo
           HELM_NAMESPACE: odoo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lint and Test Charts
-        uses: IMIO/gha/helm-test-notify@v6
+        uses: IMIO/gha/helm-test-notify@rework/mattermost-notifications
         with:
           HELM_RELEASE: odoo
           HELM_NAMESPACE: odoo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lint and Test Charts
-        uses: IMIO/gha/helm-test-notify@rework/mattermost-notifications
+        uses: IMIO/gha/helm-test-notify@v7
         with:
           HELM_RELEASE: odoo
           HELM_NAMESPACE: odoo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Upgraded GitHub Actions workflow automation to use newer versions of Helm release notification and chart testing actions, ensuring compatibility with the latest action releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->