### PR TITLE
feat: add extraInitContainers, extraVolumes and extraVolumeMounts support

### DIFF
--- a/templates/cron-deployment.yaml
+++ b/templates/cron-deployment.yaml
@@ -34,6 +34,12 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- if .Values.cron.extraInitContainers }}
+      initContainers:
+        {{- with .Values.cron.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
@@ -58,6 +64,9 @@ spec:
               readOnly: true
             - name: {{ include "..fullname" . }}-odoo-data
               mountPath: /var/lib/odoo
+            {{- with .Values.cron.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if .Values.cron.extraEnv }}
           env:
             {{- toYaml .Values.cron.extraEnv | nindent 12 }}
@@ -83,6 +92,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- with .Values.cron.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,8 +34,9 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
-      {{- if .Values.odoo.init.enabled }}
+      {{- if or .Values.odoo.init.enabled .Values.extraInitContainers }}
       initContainers:
+        {{- if .Values.odoo.init.enabled }}
         - name: init-db-odoo
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: ["/bin/bash", "-c", 'odoo -i {{ .Values.odoo.init.modules }} -d {{ .Values.postgresql.auth.database }} --stop-after-init']
@@ -44,6 +45,10 @@ spec:
               mountPath: /etc/odoo/odoo.conf
               subPath: odoo.conf
               readOnly: true
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
@@ -89,6 +94,9 @@ spec:
               readOnly: true
             - name: {{ include "..fullname" . }}-odoo-data
               mountPath: /var/lib/odoo
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if .Values.extraEnv }}
           env:
           {{- toYaml .Values.extraEnv | nindent 12 }}
@@ -123,6 +131,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -103,8 +103,11 @@ cron:
   resources: {}
   extraEnv: []
   extraEnvFrom: []
+  # Extra init containers to run before the cron container starts
   extraInitContainers: []
+  # Extra volumes to mount in the cron pod
   extraVolumes: []
+  # Extra volume mounts for the cron container
   extraVolumeMounts: []
   livenessProbe:
     httpGet:

--- a/values.yaml
+++ b/values.yaml
@@ -103,6 +103,9 @@ cron:
   resources: {}
   extraEnv: []
   extraEnvFrom: []
+  extraInitContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []
   livenessProbe:
     httpGet:
       port: odoo-http
@@ -234,6 +237,15 @@ autoscaling:
 
 # Additional environment variables from secrets or configmaps
 # extraEnvFrom:
+
+# Extra init containers
+# extraInitContainers: []
+
+# Extra volumes
+# extraVolumes: []
+
+# Extra volume mounts for the Odoo container
+# extraVolumeMounts: []
 
 podAnnotations: {}
 


### PR DESCRIPTION
Hi guys,
we'd like to use your chart in one internal project that uses Odoo but requires custom addons developed by our team. We are proposing a set of changes that would allow anyone to be able to implement this functionality by being able to use custom init containers. Hope you find it useful :) looking forward to make more contributions!

## Problem

The chart sets `addons_path = /mnt/extra-addons` in the generated `odoo.conf`, but provides no mechanism to actually mount files there. Organizations that maintain custom Odoo modules have no supported way to inject them into the pod.

## Solution

Add three new optional values, applied to both the main and cron deployments:

- `extraInitContainers` — additional init containers to run before Odoo starts
- `extraVolumes` — extra volumes to add to the pod
- `extraVolumeMounts` — extra volume mounts for the Odoo container

### Usage example

```yaml
extraInitContainers:
  - name: copy-addons
    image: registry.example.com/odoo-addons:latest
    command: ["sh", "-c", "cp -a /addons/. /mnt/extra-addons/"]
    volumeMounts:
      - name: extra-addons
        mountPath: /mnt/extra-addons

extraVolumes:
  - name: extra-addons
    emptyDir: {}

extraVolumeMounts:
  - name: extra-addons
    mountPath: /mnt/extra-addons
```

A separate container image should contain the addon files. The init container copies them into a shared `emptyDir` volume at pod startup, which is then mounted at `/mnt/extra-addons` on the Odoo container — the path already configured in `odoo.addons_path`.

## GitOps flow

When used with a GitOps tool like Flux, the addons image tag can be tracked independently via image automation. Pushing a change to the addons repository triggers:

1. CI builds a new addons image
2. Flux detects the new tag and updates the HelmRelease values
3. The pod restarts — the init container runs with the new image
4. Odoo loads the updated addons from `/mnt/extra-addons`

This cleanly separates the Odoo upgrade lifecycle from the addon development lifecycle.

## Changes

- `values.yaml`: adds `extraInitContainers`, `extraVolumes`, `extraVolumeMounts` (top-level, for main deployment) and `cron.extraInitContainers`, `cron.extraVolumes`, `cron.extraVolumeMounts` (for the cron deployment)
- `templates/deployment.yaml`: renders extra init containers, volumes and volume mounts
- `templates/cron-deployment.yaml`: same, using cron-scoped values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now support optional custom init containers through the `extraInitContainers` configuration option.
  * Added support for additional volume mounts with the `extraVolumeMounts` configuration option.
  * Added support for additional volumes with the `extraVolumes` configuration option.
  * All new options are available for both main and cron deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/helm-odoo/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->