### PR TITLE
feat: Apply extraEnv and extraEnvFrom to init-db-odoo init container

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -45,6 +45,14 @@ spec:
               mountPath: /etc/odoo/odoo.conf
               subPath: odoo.conf
               readOnly: true
+          {{- if .Values.extraEnv }}
+          env:
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
+          {{- if .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml .Values.extraEnvFrom | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}

--- a/test/local.yaml
+++ b/test/local.yaml
@@ -205,6 +205,10 @@ extraEnv:
   - name: "TEST"
     value: "test"
 
+extraEnvFrom:
+  - secretRef:
+      name: odoo-postgresql-secret
+
 # Example: inject custom Odoo addons via an init container
 extraInitContainers:
   - name: copy-addons

--- a/values.yaml
+++ b/values.yaml
@@ -236,9 +236,11 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 # Additional environment variables for the Odoo container
+# Also injected into the init-db-odoo init container when odoo.init.enabled is true
 # extraEnv:
 
 # Additional environment variables from secrets or configmaps
+# Also injected into the init-db-odoo init container when odoo.init.enabled is true
 # extraEnvFrom:
 
 # Extra init containers


### PR DESCRIPTION
The init-db-odoo init container runs odoo with the same DB and config as the main container, so it needs access to the same environment. It now reuses .Values.extraEnv and .Values.extraEnvFrom, mirroring the main Odoo container. Bumps chart to 0.4.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to inject additional environment variables into the initialization container. Supports both direct value injection through chart values and external references to Kubernetes resources, enabling flexible and secure management of initialization parameters.

* **Chores**
  * Chart version bumped to 0.4.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IMIO/helm-odoo/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->