### PR TITLE
refactor: Split PostgreSQL config into bundled (postgresql) and external (externalDatabase)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,12 @@ Both liveness and readiness probes for Odoo hit `/web/health` on the Odoo HTTP p
 
 ### PostgreSQL
 
-Bundled PostgreSQL (bitnami chart, OCI registry) is optional and controlled by `postgresql.enabled`. For production, an external PostgreSQL (e.g., CloudNativePG) is recommended. The `global.security.allowInsecureImages: true` setting is required due to the bitnami legacy repo.
+Database config is split into two clearly-scoped sections, with `postgresql.enabled` selecting which one Odoo reads:
+
+- `postgresql.*` — the **bundled** bitnami subchart (OCI registry), used when `postgresql.enabled: true` (dev/test). Odoo's connection comes from `postgresql.auth.*`, the host is auto-derived as `<release>-postgresql`, port `5432`. The `global.security.allowInsecureImages: true` setting is required due to the bitnami legacy repo. Bundled credentials are bitnami-native (inline `auth.password`/`auth.postgresPassword` or `auth.existingSecret`).
+- `externalDatabase.*` — connection settings for an **external** PostgreSQL (e.g., CloudNativePG, recommended for production), used when `postgresql.enabled: false`. `externalDatabase.host` is required in this mode.
+
+Connection resolution lives in the `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`..dbPassword` helpers in `_helpers.tpl`, which switch source based on `postgresql.enabled`.
 
 ## Key Files
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 0.4.1
+version: 1.0.0
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 1.0.0
+version: 1.0.0-alpha
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ The following table lists the configurable parameters of the helm-odoo chart and
 
 See the [values.yaml](values.yaml) file for more information.
 
+### Database configuration
+
+Database configuration is split into two clearly-scoped sections:
+
+- **`postgresql.*`** — configures the **bundled** bitnami PostgreSQL subchart, used
+  only when `postgresql.enabled: true` (intended for dev/test). Odoo's connection is
+  taken from `postgresql.auth.*`, the host is auto-derived as `<release-name>-postgresql`
+  and the port is `5432`. Bundled credentials can be set inline via
+  `postgresql.auth.password` / `postgresql.auth.postgresPassword`, or supplied through
+  `postgresql.auth.existingSecret` (bitnami-native).
+- **`externalDatabase.*`** — connection settings for an **external** PostgreSQL
+  (e.g. CloudNativePG), used only when `postgresql.enabled: false`. `externalDatabase.host`
+  is required in this mode (templating fails fast if it is empty).
+
+Only one section is ever read at a time, depending on `postgresql.enabled` — no key is
+shared between the bundled and external scenarios.
+
 ### Use an existing Secret for Odoo configuration
 
 You can use an existing secret for the Odoo configuration.
@@ -136,6 +153,21 @@ nano /etc/hosts
 Feel free to contribute by making a [pull request](https://github.com/imio/helm-odoo/pull/new/master).
 
 Please read the official [Helm Contribution Guide](https://github.com/helm/charts/blob/master/CONTRIBUTING.md) from Helm for more information on how you can contribute to this Chart.
+
+## Upgrading
+
+### To 1.0.0
+
+The single `postgresql:` section that previously held both the bundled-chart config and
+the database connection settings has been split into two clearly-scoped sections
+(`postgresql.*` for the bundled bitnami subchart, `externalDatabase.*` for an external
+database). Update your values as follows:
+
+- `postgresql.host` / `postgresql.port` → `externalDatabase.host` / `externalDatabase.port`
+  (the host is now auto-derived as `<release-name>-postgresql` for the bundled chart).
+- `postgresql.auth.admin_password` → `postgresql.auth.postgresPassword` (bitnami-native key).
+- External-database connection now lives under `externalDatabase.*` (read only when
+  `postgresql.enabled: false`).
 
 ## License
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -62,10 +62,43 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Resolve Odoo's database connection from the right source:
+- bundled (postgresql.enabled): credentials come from postgresql.auth.*, the
+  host is the bundled service "<release>-postgresql" and the port is 5432.
+- external (postgresql.enabled false): credentials come from externalDatabase.*
+  ("..dbHost" fails fast if externalDatabase.host is not set).
+These take the root context (they need .Release / .Values).
+*/}}
+{{- define "..dbHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- else -}}
+{{- required "externalDatabase.host is required when postgresql.enabled is false" .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end }}
+
+{{- define "..dbPort" -}}
+{{- if .Values.postgresql.enabled -}}5432{{- else -}}{{ .Values.externalDatabase.port }}{{- end -}}
+{{- end }}
+
+{{- define "..dbName" -}}
+{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.database }}{{- else -}}{{ .Values.externalDatabase.name }}{{- end -}}
+{{- end }}
+
+{{- define "..dbUser" -}}
+{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.username }}{{- else -}}{{ .Values.externalDatabase.user }}{{- end -}}
+{{- end }}
+
+{{- define "..dbPassword" -}}
+{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.password }}{{- else -}}{{ .Values.externalDatabase.password }}{{- end -}}
+{{- end }}
+
+{{/*
 Generate odoo.conf content.
-Call with dict: "Values" .Values "dbPassword" <password> "adminPasswd" <passwd>
-Sensitive values are passed as parameters so both secrets.yaml and
-externalsecrets.yaml can share a single source of truth.
+Call with dict: "Values" .Values "dbHost" <host> "dbPort" <port> "dbName" <name>
+"dbUser" <user> "dbPassword" <password> "adminPasswd" <passwd>
+Connection and sensitive values are passed as parameters so both secrets.yaml
+and externalsecrets.yaml can share a single source of truth.
 */}}
 {{- define "..odooConf" -}}
 [options]
@@ -85,14 +118,14 @@ limit_request = {{ .Values.odoo.limit_request | int }}
 {{- if .Values.odoo.dbfilter }}
 dbfilter = {{ .Values.odoo.dbfilter }}
 {{- end }}
-db_host = {{ .Values.postgresql.host }}
+db_host = {{ .dbHost }}
 {{- if .Values.odoo.db_name }}
-db_name = {{ .Values.postgresql.auth.database }}
+db_name = {{ .dbName }}
 {{- else }}
 db_name = False
 {{- end }}
-db_port = {{ .Values.postgresql.port }}
-db_user = {{ .Values.postgresql.auth.username }}
+db_port = {{ .dbPort }}
+db_user = {{ .dbUser }}
 db_password = {{ .dbPassword }}
 db_maxconn = {{ .Values.odoo.db_maxconn | int }}
 {{- if .Values.odoo.db_replica_host }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- if .Values.odoo.init.enabled }}
         - name: init-db-odoo
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["/bin/bash", "-c", 'odoo -i {{ .Values.odoo.init.modules }} -d {{ .Values.postgresql.auth.database }} --stop-after-init']
+          command: ["/bin/bash", "-c", 'odoo -i {{ .Values.odoo.init.modules }} -d {{ include "..dbName" . }} --stop-after-init']
           volumeMounts:
             - name: {{ include "..fullname" . }}-odoo-conf
               mountPath: /etc/odoo/odoo.conf
@@ -83,7 +83,7 @@ spec:
         - name: {{ include "..fullname" . }}-service
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
       {{- if .Values.odoo.update.enabled }}
-          command: ["/bin/bash", "-c", 'odoo --update {{ .Values.odoo.update.modules }} -d {{ .Values.postgresql.auth.database }}']
+          command: ["/bin/bash", "-c", 'odoo --update {{ .Values.odoo.update.modules }} -d {{ include "..dbName" . }}']
       {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/templates/externalsecrets.yaml
+++ b/templates/externalsecrets.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.externalsecrets.enabled }}
+{{- if .Values.postgresql.enabled }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -22,6 +23,7 @@ spec:
       key: {{ .Values.externalsecrets.postgresqlKey }}
       property: postgresql-admin-password
 ---
+{{- end }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -39,7 +41,7 @@ spec:
         labels: {}
       data:
         odoo.conf: |
-{{ include "..odooConf" (dict "Values" .Values "dbPassword" "{{ .postgresqlPassword }}" "adminPasswd" "{{ .odooAdminPasswd }}") | indent 10 }}
+{{ include "..odooConf" (dict "Values" .Values "dbHost" (include "..dbHost" .) "dbPort" (include "..dbPort" .) "dbName" (include "..dbName" .) "dbUser" (include "..dbUser" .) "dbPassword" "{{ .postgresqlPassword }}" "adminPasswd" "{{ .odooAdminPasswd }}") | indent 10 }}
   data:
   - secretKey: postgresqlPassword
     remoteRef:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -5,18 +5,6 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ include "..fullname" . }}-postgresql-secret"
-  annotations:
-    labels:
-        {{- include "..labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  postgresql-password: {{ .Values.postgresql.auth.password }}
-  postgresql-admin-password: {{ .Values.postgresql.auth.admin_password }}
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: "{{ include "..fullname" . }}-odoo-conf"
   annotations:
     labels:
@@ -24,5 +12,5 @@ metadata:
 type: Opaque
 stringData:
   odoo.conf: |
-{{ include "..odooConf" (dict "Values" .Values "dbPassword" .Values.postgresql.auth.password "adminPasswd" .Values.odoo.admin_passwd) | indent 4 }}
+{{ include "..odooConf" (dict "Values" .Values "dbHost" (include "..dbHost" .) "dbPort" (include "..dbPort" .) "dbName" (include "..dbName" .) "dbUser" (include "..dbUser" .) "dbPassword" (include "..dbPassword" .) "adminPasswd" .Values.odoo.admin_passwd) | indent 4 }}
 {{- end }}

--- a/test/local.yaml
+++ b/test/local.yaml
@@ -92,27 +92,25 @@ cron:
     failureThreshold: 6
     successThreshold: 1
 
+# External DB connection — used only when postgresql.enabled is false.
+externalDatabase:
+  # host: "10.7.121.11"
+  port: 5432
+  name: odoo
+  user: odoo
+  password: mySecuredPassword
+
+# Bundled bitnami PostgreSQL for local testing.
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 postgresql:
-  ## If true, install the Postgresql chart
-  ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
-  ## If false, use an external postgresql database
   enabled: true
   auth:
-    # Seems hardcoded: https://github.com/odoo/docker/blob/master/16.0/wait-for-psql.py#L21C5-L21C5
     # Database name should be false if you are using a multi-tenant setup
     # In this case, we are using the dbfilter option in the odoo section
     database: odoo
     username: odoo
     password: mySecuredPassword
-    admin_password: mySecuredPassword
-    existingSecret: odoo-postgresql-secret
-    secretKeys:
-      adminPasswordKey: postgresql-admin-password
-      userPasswordKey: postgresql-password
-  ## host of the external postgresql database
-  # external: "10.7.121.11"
-  host: "odoo-postgresql"
-  port: 5432
+    postgresPassword: mySecuredPassword
   primary:
     persistence:
       enabled: false
@@ -206,8 +204,9 @@ extraEnv:
     value: "test"
 
 extraEnvFrom:
+  # Bundled bitnami DB self-manages this secret (<release>-postgresql)
   - secretRef:
-      name: odoo-postgresql-secret
+      name: odoo-postgresql
 
 # Example: inject custom Odoo addons via an init container
 extraInitContainers:

--- a/values.yaml
+++ b/values.yaml
@@ -119,10 +119,28 @@ cron:
     failureThreshold: 6
     successThreshold: 1
 
+# Connection settings for an EXTERNAL PostgreSQL database.
+# Used ONLY when postgresql.enabled is false. When the bundled chart is
+# enabled, connection settings come from the postgresql.* section below instead.
+externalDatabase:
+  ## Hostname of the external PostgreSQL server (e.g. a CloudNativePG service).
+  ## REQUIRED when postgresql.enabled is false.
+  host: ""
+  port: 5432
+  ## Database name. Set odoo.db_name: false for a multi-tenant (dbfilter) setup.
+  name: odoo
+  user: odoo
+  ## Password Odoo uses to connect. With the default (generated) secret backend
+  ## this is written into odoo.conf. Use existingSecret/externalsecrets to keep
+  ## it out of plaintext values.
+  password: mySecuredPassword
+
+# Bundled PostgreSQL (bitnami subchart) — intended for dev/test.
+# Set enabled: false to use an external database (configure externalDatabase above).
+# Passwords can be set inline via auth.password/auth.postgresPassword, OR supplied
+# through auth.existingSecret (bitnami-native).
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 postgresql:
-  ## If true, install the Postgresql chart
-  ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
-  ## If false, use an external postgresql database
   enabled: true
   global:
     security:
@@ -134,16 +152,16 @@ postgresql:
     # In this case, we are using the dbfilter option in the odoo section
     database: odoo
     username: odoo
-    # password: managed by a Kubernetes secret, you could use existing one
+    # password: managed by a Kubernetes secret, you could use an existing one
     password: mySecuredPassword
-    admin_password: mySecuredPassword
-    existingSecret: odoo-postgresql-secret
-    secretKeys:
-      adminPasswordKey: postgresql-admin-password
-      userPasswordKey: postgresql-password
-  ## host of the external postgresql database
-  host: "odoo-postgresql"
-  port: 5432
+    # postgresPassword is the superuser (postgres) password
+    postgresPassword: mySecuredPassword
+    # To supply credentials from an existing secret instead of the inline values
+    # above, uncomment and point at your secret:
+    # existingSecret: my-db-secret
+    # secretKeys:
+    #   adminPasswordKey: postgres-password
+    #   userPasswordKey: password
   primary:
     persistence:
       enabled: false


### PR DESCRIPTION
## Summary

The single `postgresql:` block in `values.yaml` was doing two unrelated jobs at once: configuring the **bundled** bitnami PostgreSQL subchart *and* holding Odoo's **database connection** settings (used even for external databases). It also mixed in keys that aren't part of bitnami's schema at all (`host`, `port`, `auth.admin_password`), so connecting to an external DB meant editing a section that looked like it configured the bundled chart.

This PR splits that into two clearly-scoped sections, selected by `postgresql.enabled`:

- **`postgresql.*`** — the bundled bitnami subchart only (dev/test). Odoo's connection is auto-derived: host = `<release>-postgresql`, port `5432`, credentials from `postgresql.auth.*`. Passwords stay bitnami-native (inline `auth.password`/`auth.postgresPassword`, or `auth.existingSecret`).
- **`externalDatabase.*`** — connection settings for an external PostgreSQL (e.g. CloudNativePG), read only when `postgresql.enabled: false`. `externalDatabase.host` is **required** in this mode (templating fails fast otherwise).

Only one section is ever read at a time — no key is shared between the two scenarios.

This also fixes a latent footgun: the hardcoded `host: "odoo-postgresql"` only worked when the release happened to be named `odoo`. The host is now derived from the release name.

> [!WARNING]
> **Breaking change** — chart bumped to `1.0.0`. See the migration notes below.

## Changes

- **`values.yaml` / `test/local.yaml`** — new `externalDatabase:` section + slimmed bitnami-only `postgresql:` section.
- **`templates/_helpers.tpl`** — new `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`..dbPassword` resolvers that switch source on `postgresql.enabled`; `..odooConf` now consumes the resolved values.
- **`templates/secrets.yaml`** — dropped the redundant chart-generated `-postgresql-secret`; the bundled bitnami DB now self-manages its secret (`<release>-postgresql`).
- **`templates/externalsecrets.yaml`** — the postgresql ExternalSecret is gated on `postgresql.enabled`; the odoo.conf template now receives resolved connection values (Vault password placeholders unchanged).
- **`templates/deployment.yaml`** — init/update `-d` flags use the resolved `..dbName`.
- **`Chart.yaml`** — `0.4.1` → `1.0.0`.
- **`README.md` / `CLAUDE.md`** — documented the split; added an **Upgrading → To 1.0.0** section with the migration steps.

## Migration (0.4.x → 1.0.0)

- `postgresql.host` / `postgresql.port` → `externalDatabase.host` / `externalDatabase.port` (host auto-derived for the bundled chart).
- `postgresql.auth.admin_password` → `postgresql.auth.postgresPassword` (bitnami-native key).
- External-database connection now lives under `externalDatabase.*`.
- Anything referencing the old chart-generated `<release>-postgresql-secret` should use bitnami's self-managed `<release>-postgresql` secret instead.

## Verification

- `helm lint .` and `helm lint -f test/local.yaml .` pass.
- **Bundled** (`-f test/local.yaml`): renders `db_host = odoo-postgresql`, credentials from `postgresql.auth`, bitnami StatefulSet present.
- **External** (`postgresql.enabled=false`, `externalDatabase.host=…`): connection sourced from `externalDatabase.*`, **no** bitnami resources, `-d <name>` resolved correctly.
- **External without a host**: fails fast with `externalDatabase.host is required when postgresql.enabled is false`.
- **external-secrets**: bundled renders both ExternalSecrets; external correctly omits the postgresql one; Vault placeholders intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for external PostgreSQL alongside bundled DB, with new configurable externalDatabase block.

* **Documentation**
  * Clarified bundled vs external DB configuration, added upgrade/migration notes for 1.0.0.

* **Chores**
  * Bumped chart version to 1.0.0-alpha.

* **Bug Fixes / Improvements**
  * Centralized DB connection rendering and adjusted secret/templating behavior to fail fast when required external fields are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->