### PR TITLE
feat: run Odoo init/update as Helm hook Jobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,13 +55,38 @@ Nginx configuration is in a ConfigMap (`templates/configmap.yaml`).
 
 ### Database init & update (Helm hook Jobs)
 
-DB lifecycle is handled by Helm hook Jobs in `templates/hooks/`, **not** inside the main deployment (the old `init-db-odoo` initContainer and `odoo --update` command override were removed):
+DB lifecycle is handled by Helm hook Jobs in `templates/hooks/`, **not** inside the main deployment (the old `init-db-odoo` initContainer and `odoo --update` command override were removed). Both Jobs run on **`pre-install,pre-upgrade`**, so they execute *before* the Odoo/cron deployments are (re)applied. Each Job's `prepare` initContainer scales any running Odoo/cron to 0 (a no-op on a fresh install, since the deployments don't exist yet), and a `wait-for-db` initContainer (`odoo.hooks.waitForDb`) blocks on the DB host:port. **No install-time replica gating or scale-up hook is needed** — at `pre-install` the deployments don't exist; afterwards Helm creates them at their normal replicas, and on upgrade Helm re-applies them, bringing Odoo back up.
 
-- **Init** (`odoo.init.enabled`) — a `post-install` hook Job (`hooks/job-init.yaml`) that runs `odoo -i <modules> -d <db> --stop-after-init` **once, on first install only**. A single Job regardless of replica count. An optional `wait-for-db` initContainer (`odoo.hooks.waitForDb`) blocks on the DB host:port first.
-- **Update** (`odoo.update.enabled`, default **false**) — a `pre-upgrade` hook Job (`hooks/job-update.yaml`) that runs on `helm upgrade`. Its `prepare` initContainer (image `odoo.hooks.kubectlImage`, default `alpine/kubectl:1.36.1`) scales Odoo (and cron) to 0 and waits for their pods to terminate, then the Job runs `odoo -u <modules> --stop-after-init`. Helm then re-applies the deployment, bringing Odoo back up with the new image. Set `update.enabled: true` only for a version bump (it causes downtime + migration). RBAC for the scale/wait lives in `hooks/rbac.yaml` (rendered only when update is enabled).
-Hook Jobs mount only the `odoo.conf` secret (no PVC). (Multi-tenant / Indexed-Job support is planned for a later release.)
+- **Init** (`odoo.init.enabled`) — `hooks/job-init.yaml`, hook-weight `0`. Runs `odoo -i <modules> -d <db> --stop-after-init`. `enabled` is a **one-shot intent**: set it true to initialise on install, or to **re-initialise after trashing the DB** (`helm upgrade` with `odoo.init.enabled=true`), then set it back to false (left on, every upgrade re-runs `odoo -i`).
+- **Update** (`odoo.update.enabled`, default **false**) — `hooks/job-update.yaml`, hook-weight `10` (so init at `0` completes first when both are enabled). Runs `odoo -u <modules> --stop-after-init`. Set true only for a version bump (downtime + migration); `odoo -u` needs an already-initialised DB.
 
-Shared Job spec lives in `_helpers.tpl` helpers: `..hookOdooContainer` and `..hookVolumes`.
+RBAC for the scale-down lives in `hooks/rbac.yaml` (rendered when `init.enabled` **or** `update.enabled`, weight `-10`). The `prepare` initContainer image is `odoo.hooks.kubectlImage` (default `alpine/kubectl:1.36.1`). Hook Jobs mount only an `odoo.conf` secret (no PVC). (Multi-tenant / Indexed-Job support is planned for a later release.)
+
+**Pre-install dependency model** (the hooks run *before* the chart's normal resources, so everything they
+need is itself provisioned as a pre-install hook; a pod that mounts a not-yet-created secret stays in
+`ContainerCreating` and kubelet retries the mount until it appears, so "synced during pre-install" is enough):
+- **odoo.conf secret** — all three backends expose `<fullname>-odoo-conf` at/before hook time, and the Jobs
+  (and the deployment) mount that one name via `..hookVolumes`:
+  - *generated/classic* — `templates/secrets.yaml` renders it as a `pre-install,pre-upgrade` hook
+    (weight `-15`, `before-hook-creation`). It is a hook **unconditionally** (not gated on init/update):
+    a secret that flips hook↔normal on toggle trips Helm's ownership check (`invalid ownership metadata`).
+    Consequences accepted: recreated each upgrade (kubelet re-mounts), absent from `helm get manifest`,
+    not rollback-restored (it persists, so the deployment keeps mounting it).
+  - *existingSecret* — the user's secret pre-exists; mounted directly.
+  - *externalsecrets* — `templates/externalsecrets.yaml` renders the `ExternalSecret`s as `pre-install,pre-upgrade`
+    hooks; the operator syncs `<fullname>-odoo-conf` during the pre-install phase and the Job's mount retries
+    until it lands. (Helm's hook wait only blocks on Pods/Jobs, not CR status, so this relies on the operator
+    syncing within `--timeout`.)
+- **Bundled PostgreSQL** — Helm cannot deploy a subchart before the parent's pre-install hooks, so the bundled
+  bitnami Postgres (`postgresql.enabled: true`) is not up when the hooks run. To use it with the hooks (dev/test),
+  run Postgres itself as a pre-install hook via `postgresql.commonAnnotations` (`helm.sh/hook: pre-install`,
+  weight below `0`) — see `test/local.yaml`. Production should use an external DB. The Jobs' DB connection
+  resolves through the `..dbHost`/`..dbPort`/… helpers.
+
+`before-hook-creation` is required on these secret hooks: Helm Creates hook resources, so a re-run on the next
+upgrade would otherwise fail with `already exists`.
+
+Shared Job spec lives in `_helpers.tpl` helpers: `..hookOdooContainer`, `..hookVolumes`, `..hookScaleDownInitContainer` (the `prepare` scale-down) and `..hookWaitForDbInitContainer` (reused by both Jobs).
 
 ### Maintenance Mode
 
@@ -71,7 +96,7 @@ When `maintenance.enabled: true`, the chart:
 - Deploys a maintenance page (custom HTML or default)
 - Redirects Ingress traffic to the maintenance service
 
-The update hook reuses this same maintenance nginx (config/HTML ConfigMaps) but brings up its own `pre-upgrade` hook copy of the maintenance Deployment (`hooks/maintenance-hook.yaml`). Crucially, that pod carries the chart's `selectorLabels` and a `nginx-http` port, so the existing `<fullname>-nginx` Service routes to it while Odoo is scaled to 0 — **the ingress is never modified** (an earlier `kubectl patch` approach was abandoned because Helm's 3-way merge does not revert out-of-band ingress edits when the rendered ingress manifest is unchanged). The hook is torn down once the update Job succeeds, and the Service routes back to Odoo.
+The update/re-init hooks reuse this same maintenance nginx (config/HTML ConfigMaps) but bring up their own `pre-upgrade` hook copy of the maintenance Deployment (`hooks/maintenance-hook.yaml`, rendered when `update.enabled` **or** `init.enabled`, with `maintenancePage` + `ingress.enabled`). Crucially, that pod carries the chart's `selectorLabels` and a `nginx-http` port, so the existing `<fullname>-nginx` Service routes to it while Odoo is scaled to 0 — **the ingress is never modified** (an earlier `kubectl patch` approach was abandoned because Helm's 3-way merge does not revert out-of-band ingress edits when the rendered ingress manifest is unchanged). The hook is torn down once the upgrade hooks succeed, and the Service routes back to Odoo.
 
 ### Health Checks
 
@@ -96,7 +121,7 @@ Connection resolution lives in the `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`
 | `templates/secrets.yaml` | PostgreSQL credentials and `odoo.conf` secret |
 | `templates/configmap.yaml` | Nginx config and maintenance page HTML |
 | `templates/externalsecrets.yaml` | Vault/external-secrets integration |
-| `templates/hooks/` | Init (`post-install`) / update (`pre-upgrade`) hook Jobs, RBAC, maintenance-page hook |
+| `templates/hooks/` | Init / update hook Jobs (both `pre-install,pre-upgrade`; init weight `0` < update weight `10`), RBAC, maintenance-page hook |
 | `test/local.yaml` | Development overrides (ingress enabled, `odoo.local` hostname) |
 
 ## CI/CD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,17 @@ Odoo is configured via `odoo.conf` injected as a Kubernetes Secret. Three mutual
 2. **Existing Secret**: Reference a pre-created Kubernetes Secret (`existingSecret.enabled: true`)
 3. **External Secrets**: Vault integration via external-secrets.io operator (`externalsecrets.enabled: true`)
 
+The `odoo.conf` secret is **split by lifecycle** (generated + externalsecrets backends):
+- `<fullname>-odoo-conf` — a **normal** (Helm-tracked) Secret mounted by the Odoo + cron deployments. Tracked in `helm get manifest`, rollback-aware, stable across upgrades.
+- `<fullname>-odoo-conf-hook` — a **hook** copy mounted only by the init/update Jobs (which run at `pre-install`, before normal resources exist). Rendered only when `init.enabled || update.enabled`.
+
+Both copies share the same `odoo.conf` content via the `..odooConf` helper (single source of truth). With `existingSecret`, the user's single pre-existing `<fullname>-odoo-conf` serves both — no hook copy. See the pre-install dependency model below for why the split exists.
+
 Nginx configuration is in a ConfigMap (`templates/configmap.yaml`).
 
 ### Database init & update (Helm hook Jobs)
 
-DB lifecycle is handled by Helm hook Jobs in `templates/hooks/`, **not** inside the main deployment (the old `init-db-odoo` initContainer and `odoo --update` command override were removed). Both Jobs run on **`pre-install,pre-upgrade`**, so they execute *before* the Odoo/cron deployments are (re)applied. Each Job's `prepare` initContainer scales any running Odoo/cron to 0 (a no-op on a fresh install, since the deployments don't exist yet), and a `wait-for-db` initContainer (`odoo.hooks.waitForDb`) blocks on the DB host:port. **No install-time replica gating or scale-up hook is needed** — at `pre-install` the deployments don't exist; afterwards Helm creates them at their normal replicas, and on upgrade Helm re-applies them, bringing Odoo back up.
+DB lifecycle is handled by Helm hook Jobs in `templates/hooks/`. Both Jobs run on **`pre-install,pre-upgrade`**, so they execute *before* the Odoo/cron deployments are (re)applied. Each Job's `prepare` initContainer scales any running Odoo/cron to 0 (a no-op on a fresh install, since the deployments don't exist yet), and a `wait-for-db` initContainer (`odoo.hooks.waitForDb`) blocks on the DB host:port. **No install-time replica gating or scale-up hook is needed** — at `pre-install` the deployments don't exist; afterwards Helm creates them at their normal replicas, and on upgrade Helm re-applies them, bringing Odoo back up.
 
 - **Init** (`odoo.init.enabled`) — `hooks/job-init.yaml`, hook-weight `0`. Runs `odoo -i <modules> -d <db> --stop-after-init`. `enabled` is a **one-shot intent**: set it true to initialise on install, or to **re-initialise after trashing the DB** (`helm upgrade` with `odoo.init.enabled=true`), then set it back to false (left on, every upgrade re-runs `odoo -i`).
 - **Update** (`odoo.update.enabled`, default **false**) — `hooks/job-update.yaml`, hook-weight `10` (so init at `0` completes first when both are enabled). Runs `odoo -u <modules> --stop-after-init`. Set true only for a version bump (downtime + migration); `odoo -u` needs an already-initialised DB.
@@ -65,26 +71,36 @@ RBAC for the scale-down lives in `hooks/rbac.yaml` (rendered when `init.enabled`
 **Pre-install dependency model** (the hooks run *before* the chart's normal resources, so everything they
 need is itself provisioned as a pre-install hook; a pod that mounts a not-yet-created secret stays in
 `ContainerCreating` and kubelet retries the mount until it appears, so "synced during pre-install" is enough):
-- **odoo.conf secret** — all three backends expose `<fullname>-odoo-conf` at/before hook time, and the Jobs
-  (and the deployment) mount that one name via `..hookVolumes`:
-  - *generated/classic* — `templates/secrets.yaml` renders it as a `pre-install,pre-upgrade` hook
-    (weight `-15`, `before-hook-creation`). It is a hook **unconditionally** (not gated on init/update):
-    a secret that flips hook↔normal on toggle trips Helm's ownership check (`invalid ownership metadata`).
-    Consequences accepted: recreated each upgrade (kubelet re-mounts), absent from `helm get manifest`,
-    not rollback-restored (it persists, so the deployment keeps mounting it).
-  - *existingSecret* — the user's secret pre-exists; mounted directly.
-  - *externalsecrets* — `templates/externalsecrets.yaml` renders the `ExternalSecret`s as `pre-install,pre-upgrade`
-    hooks; the operator syncs `<fullname>-odoo-conf` during the pre-install phase and the Job's mount retries
-    until it lands. (Helm's hook wait only blocks on Pods/Jobs, not CR status, so this relies on the operator
-    syncing within `--timeout`.)
+- **odoo.conf secret** — the Jobs run at `pre-install`, so they need a secret that exists *before* the chart's
+  normal resources. Rather than force one secret to be both a pre-install hook and the deployment's persistent
+  resource (the old approach made it a hook **unconditionally**, accepting: recreated each upgrade, absent from
+  `helm get manifest`, not rollback-restored — all to dodge the hook↔normal flip that trips Helm's ownership
+  check, `invalid ownership metadata`), the secret is **split by lifecycle**. The Jobs mount the hook copy via
+  `..hookVolumes`; the deployment/cron mount the normal copy directly. Neither copy ever changes type, so neither
+  trips the ownership check, and the hook copy is gated on `init.enabled || update.enabled`.
+  - *generated/classic* — `templates/secrets.yaml` renders **two** Secrets: the normal `<fullname>-odoo-conf`
+    (always) and, when `init/update` is enabled, the hook `<fullname>-odoo-conf-hook` (`pre-install,pre-upgrade`,
+    weight `-15`, `before-hook-creation`).
+  - *existingSecret* — the user's single `<fullname>-odoo-conf` pre-exists; mounted directly by both the Jobs
+    (`..hookVolumes` drops the `-hook` suffix here) and the deployment. No hook copy.
+  - *externalsecrets* — `templates/externalsecrets.yaml` renders a **normal** `ExternalSecret` (target
+    `<fullname>-odoo-conf`, always) plus, when `init/update` is enabled, a **hook** `ExternalSecret` (target
+    `<fullname>-odoo-conf-hook`, `pre-install,pre-upgrade`). The operator syncs each target during its phase;
+    the Job's mount retries until it lands. (Helm's hook wait only blocks on Pods/Jobs, not CR status, so this
+    relies on the operator syncing within `--timeout`.)
 - **Bundled PostgreSQL** — Helm cannot deploy a subchart before the parent's pre-install hooks, so the bundled
   bitnami Postgres (`postgresql.enabled: true`) is not up when the hooks run. To use it with the hooks (dev/test),
   run Postgres itself as a pre-install hook via `postgresql.commonAnnotations` (`helm.sh/hook: pre-install`,
   weight below `0`) — see `test/local.yaml`. Production should use an external DB. The Jobs' DB connection
   resolves through the `..dbHost`/`..dbPort`/… helpers.
 
-`before-hook-creation` is required on these secret hooks: Helm Creates hook resources, so a re-run on the next
-upgrade would otherwise fail with `already exists`.
+`before-hook-creation` is required on the hook copy (`<fullname>-odoo-conf-hook`): Helm Creates hook resources,
+so a re-run on the next upgrade would otherwise fail with `already exists`.
+
+> **Migration note** — In released versions `<fullname>-odoo-conf` is already a *normal* secret, so upgrading to
+> the split layout is seamless (normal→normal). Only an intermediate dev build where `<fullname>-odoo-conf` was a
+> *hook* would flip it hook→normal and hit `invalid ownership metadata`; if you ran such a build, delete the stale
+> secret (`kubectl delete secret <release>-odoo-conf`) before upgrading, or reinstall.
 
 Shared Job spec lives in `_helpers.tpl` helpers: `..hookOdooContainer`, `..hookVolumes`, `..hookScaleDownInitContainer` (the `prepare` scale-down) and `..hookWaitForDbInitContainer` (reused by both Jobs).
 
@@ -118,7 +134,7 @@ Connection resolution lives in the `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`
 | `values.yaml` | All default configuration with inline comments |
 | `templates/_helpers.tpl` | Shared template helpers (names, labels, selectors) |
 | `templates/deployment.yaml` | Main Odoo + Nginx pod definition |
-| `templates/secrets.yaml` | PostgreSQL credentials and `odoo.conf` secret |
+| `templates/secrets.yaml` | Generated `odoo.conf` secret — normal `<fullname>-odoo-conf` + gated hook `<fullname>-odoo-conf-hook` |
 | `templates/configmap.yaml` | Nginx config and maintenance page HTML |
 | `templates/externalsecrets.yaml` | Vault/external-secrets integration |
 | `templates/hooks/` | Init / update hook Jobs (both `pre-install,pre-upgrade`; init weight `0` < update weight `10`), RBAC, maintenance-page hook |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,16 @@ Odoo is configured via `odoo.conf` injected as a Kubernetes Secret. Three mutual
 
 Nginx configuration is in a ConfigMap (`templates/configmap.yaml`).
 
+### Database init & update (Helm hook Jobs)
+
+DB lifecycle is handled by Helm hook Jobs in `templates/hooks/`, **not** inside the main deployment (the old `init-db-odoo` initContainer and `odoo --update` command override were removed):
+
+- **Init** (`odoo.init.enabled`) — a `post-install` hook Job (`hooks/job-init.yaml`) that runs `odoo -i <modules> -d <db> --stop-after-init` **once, on first install only**. A single Job regardless of replica count. An optional `wait-for-db` initContainer (`odoo.hooks.waitForDb`) blocks on the DB host:port first.
+- **Update** (`odoo.update.enabled`, default **false**) — a `pre-upgrade` hook Job (`hooks/job-update.yaml`) that runs on `helm upgrade`. Its `prepare` initContainer (image `odoo.hooks.kubectlImage`, default `alpine/kubectl:1.36.1`) scales Odoo (and cron) to 0 and waits for their pods to terminate, then the Job runs `odoo -u <modules> --stop-after-init`. Helm then re-applies the deployment, bringing Odoo back up with the new image. Set `update.enabled: true` only for a version bump (it causes downtime + migration). RBAC for the scale/wait lives in `hooks/rbac.yaml` (rendered only when update is enabled).
+Hook Jobs mount only the `odoo.conf` secret (no PVC). (Multi-tenant / Indexed-Job support is planned for a later release.)
+
+Shared Job spec lives in `_helpers.tpl` helpers: `..hookOdooContainer` and `..hookVolumes`.
+
 ### Maintenance Mode
 
 When `maintenance.enabled: true`, the chart:
@@ -60,6 +70,8 @@ When `maintenance.enabled: true`, the chart:
 - Scales the cron deployment to 0 replicas (so scheduled actions don't write to the DB during migrations/restores)
 - Deploys a maintenance page (custom HTML or default)
 - Redirects Ingress traffic to the maintenance service
+
+The update hook reuses this same maintenance nginx (config/HTML ConfigMaps) but brings up its own `pre-upgrade` hook copy of the maintenance Deployment (`hooks/maintenance-hook.yaml`). Crucially, that pod carries the chart's `selectorLabels` and a `nginx-http` port, so the existing `<fullname>-nginx` Service routes to it while Odoo is scaled to 0 — **the ingress is never modified** (an earlier `kubectl patch` approach was abandoned because Helm's 3-way merge does not revert out-of-band ingress edits when the rendered ingress manifest is unchanged). The hook is torn down once the update Job succeeds, and the Service routes back to Odoo.
 
 ### Health Checks
 
@@ -84,6 +96,7 @@ Connection resolution lives in the `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`
 | `templates/secrets.yaml` | PostgreSQL credentials and `odoo.conf` secret |
 | `templates/configmap.yaml` | Nginx config and maintenance page HTML |
 | `templates/externalsecrets.yaml` | Vault/external-secrets integration |
+| `templates/hooks/` | Init (`post-install`) / update (`pre-upgrade`) hook Jobs, RBAC, maintenance-page hook |
 | `test/local.yaml` | Development overrides (ingress enabled, `odoo.local` hostname) |
 
 ## CI/CD

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 1.0.0-alpha
+version: 1.0.0-beta
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo

--- a/README.md
+++ b/README.md
@@ -100,54 +100,27 @@ You need to have the external-secrets.io operator installed in your cluster. See
 
 ### Database initialization and updates
 
-Database lifecycle is handled by **Helm hook Jobs** rather than inside the main
-deployment. Both Jobs run on **`pre-install` and `pre-upgrade`**, so they execute
-*before* the Odoo (and cron) deployments are created or re-applied — nothing writes to
-the database while they run, and Odoo never starts against an uninitialised DB. Each Job
-first scales any **running** Odoo/cron to 0 (a no-op on a fresh install, where they don't
-exist yet) and waits for the database to be reachable; afterwards Helm brings the
-deployments up at their normal replica counts.
+Database lifecycle is handled by **Helm hook Jobs** that run at `pre-install` and
+`pre-upgrade` — before the Odoo/cron deployments are created or re-applied. Each Job
+scales any running Odoo/cron to 0, waits for the database to be reachable, then runs
+the migration; Helm brings the deployments back up afterwards.
 
 #### Initialization (`odoo.init`)
-
-When `odoo.init.enabled: true`, the init hook Job runs `odoo -i <modules> -d <db>
---stop-after-init` at hook-weight `0` (before the update Job).
 
 ```yaml
 odoo:
   init:
     enabled: true
-    modules: base,web   # modules to install on the fresh database
+    modules: base,web
 ```
 
-> [!NOTE]
-> `odoo.init.enabled` is a **one-shot** intent. Set it `true` to initialise the database on
-> install, **or to re-initialise after wiping the DB**: run
-> `helm upgrade ... --set odoo.init.enabled=true` and the init Job scales Odoo/cron to 0,
-> re-runs `odoo -i`, then Helm brings them back up. Set it back to `false` afterwards —
-> left on, every `helm upgrade` re-runs `odoo -i` (a no-op on already-installed modules,
-> but it scales Odoo to 0 for the duration).
-
-An optional `wait-for-db` init container (`odoo.hooks.waitForDb`, default `true`) blocks
-on the database `host:port` before running.
+Runs `odoo -i <modules> -d <db> --stop-after-init`. Treat `enabled` as a **one-shot
+intent**: set it `true` to initialise on install or to re-initialise after wiping the
+DB, then set it back to `false` — left on, every upgrade re-runs `odoo -i` (which
+scales Odoo to 0 for the duration, even though the command itself is a no-op on an
+already-installed database).
 
 #### Updates (`odoo.update`)
-
-When `odoo.update.enabled: true`, the update hook Job runs at hook-weight `10` (after
-init). It:
-
-1. scales the Odoo deployment (and the cron deployment, if enabled) to **0 replicas**,
-2. optionally serves a maintenance page while the migration runs
-   (`odoo.update.maintenancePage: true`, requires `ingress.enabled`),
-3. runs `odoo -u <modules> -d <db> --stop-after-init`,
-
-after which Helm re-applies the deployment, bringing Odoo back up with the new image.
-`odoo -u` requires an already-initialised database (use `odoo.init` for a brand-new DB).
-
-The maintenance page is served **without modifying the ingress**: a temporary maintenance
-pod is created with the same labels the `<release>-nginx` Service selects on, so while Odoo
-is scaled to 0 that Service routes to the maintenance pod, and routes back to Odoo once the
-pod is torn down and Odoo returns.
 
 ```yaml
 odoo:
@@ -157,33 +130,21 @@ odoo:
     maintenancePage: true
 ```
 
+Runs `odoo -u <modules> -d <db> --stop-after-init` (requires an already-initialised
+DB). With `maintenancePage: true` (requires `ingress.enabled`), a temporary maintenance
+pod is created that the `<release>-nginx` Service routes to while Odoo is scaled to 0,
+without touching the ingress.
+
 > [!IMPORTANT]
-> `odoo.update.enabled` defaults to `false`. Enable it **only** for the upgrade that bumps
-> the Odoo image/version, then set it back to `false` — leaving it on means a scale-to-0
-> migration runs on **every** `helm upgrade`. The init/update hooks share a small RBAC
-> (ServiceAccount/Role/RoleBinding) so they can scale the deployments to 0 and wait for
-> their pods to terminate; it is rendered while `odoo.init.enabled` **or**
-> `odoo.update.enabled` is true.
-
-The kubectl image used by the init/update hooks is configurable via `odoo.hooks.kubectlImage`
-(default `alpine/kubectl:1.36.1`).
+> Set `odoo.update.enabled` back to `false` after the upgrade — left on, a
+> scale-to-0 migration runs on every `helm upgrade`.
 
 > [!NOTE]
-> **Bundled PostgreSQL + hooks:** the hooks run at `pre-install`, and Helm cannot deploy a
-> dependency before the parent's pre-install hooks, so the bundled bitnami PostgreSQL
-> (`postgresql.enabled: true`) is not up when they run. To use it together with the hooks
-> (dev/test), run PostgreSQL itself as a pre-install hook via `postgresql.commonAnnotations`
-> (`helm.sh/hook: pre-install` with a weight below `0`) — see `test/local.yaml`. For
-> production, use an external database (`postgresql.enabled: false` + `externalDatabase.*`).
-
-> [!NOTE]
-> **odoo.conf secret + hooks:** because the hooks run at `pre-install`, the secret they mount
-> is provisioned *before* them. The Jobs (and the deployment) always mount `<release>-odoo-conf`:
-> in **generated** mode the chart renders it as a `pre-install,pre-upgrade` hook (so it's a Helm
-> hook even without init/update — recreated each upgrade, not shown in `helm get manifest`/rollback;
-> harmless because kubelet re-mounts); in **existingSecret** mode it pre-exists; in **externalsecrets**
-> mode the `ExternalSecret` is also a pre-install hook, so the operator syncs the secret during
-> pre-install and the Job's mount retries until it appears (the operator must sync within `--timeout`).
+> **Bundled PostgreSQL + hooks:** Helm cannot deploy a subchart before the parent's
+> `pre-install` hooks, so `postgresql.enabled: true` is not up when the Jobs run. For
+> dev/test, run PostgreSQL as a pre-install hook via `postgresql.commonAnnotations`
+> (`helm.sh/hook: pre-install`, weight below `0`) — see `test/local.yaml`. Production
+> should use an external database (`postgresql.enabled: false` + `externalDatabase.*`).
 
 ## Local Setup for development
 
@@ -282,8 +243,8 @@ in favor of [Helm hook Jobs](#database-initialization-and-updates). Notable chan
 
 - **`odoo.update.enabled` now defaults to `false`** (was `true`). Previously the running
   Odoo container ran `odoo --update` on every start; now an enabled update is a
-  `pre-install,pre-upgrade` hook Job that scales Odoo to 0 and migrates. Enable it only for
-  the upgrade that bumps the Odoo version, then set it back to `false`.
+  `pre-install,pre-upgrade` hook Job that scales Odoo to 0 and migrates. Enable it only to
+  upgrade Odoo modules, then set it back to `false`.
 - `odoo.init.enabled` now drives a `pre-install,pre-upgrade` hook Job (a single Job, not
   per-replica / per-restart) that runs before Odoo starts; it can be re-run to
   re-initialise a wiped database via `helm upgrade`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This [Helm](https://helm.sh/) chart installs `Odoo` in a [Kubernetes](https://ku
 ## Prerequisites
 
 > [!NOTE]
-> For production environments, it is recommended to use [CloudNativePG](https://github.com/cloudnative-pg/cloudnative-pg) for PostgreSQL. The bundled chart is primarily intended for testing and development purposes. Be also aware of the upcoming changes to the bitnami catalog described in this [issue](https://github.com/bitnami/containers/issues/83267). 
+> For production environments, it is recommended to use [CloudNativePG](https://github.com/cloudnative-pg/cloudnative-pg) for PostgreSQL. The bundled chart is primarily intended for testing and development purposes, do not use it in production. Be also aware of the upcoming changes to the bitnami catalog described in this [issue](https://github.com/bitnami/containers/issues/83267). 
 
 - Kubernetes cluster 1.25+
 - Helm 3.8.0+
@@ -138,6 +138,7 @@ without touching the ingress.
 > [!IMPORTANT]
 > Set `odoo.update.enabled` back to `false` after the upgrade — left on, a
 > scale-to-0 migration runs on every `helm upgrade`.
+
 > [!NOTE]
 > **Bundled PostgreSQL + hooks:** Helm cannot deploy a subchart before the parent's
 > `pre-install` hooks, so `postgresql.enabled: true` is not up when the Jobs run. For

--- a/README.md
+++ b/README.md
@@ -98,6 +98,72 @@ You need to have the external-secrets.io operator installed in your cluster. See
 > Enabling both will cause `helm install`/`helm upgrade` to fail with an explicit error.
 > Choose exactly one secret backend, or leave both disabled to have the chart generate secrets from `values.yaml`.
 
+### Database initialization and updates
+
+Database lifecycle is handled by **Helm hook Jobs** rather than inside the main
+deployment. This keeps a single Job per operation (regardless of replica count) and
+makes sure nothing writes to the database while a migration is running.
+
+#### Initialization (`odoo.init`)
+
+When `odoo.init.enabled: true`, a **`post-install` hook Job** runs **once, on the first
+`helm install`**, executing `odoo -i <modules> -d <db> --stop-after-init`. It does not
+re-run on later upgrades or pod restarts.
+
+```yaml
+odoo:
+  init:
+    enabled: true
+    modules: base,web   # modules to install on the fresh database
+```
+
+An optional `wait-for-db` init container (`odoo.hooks.waitForDb`, default `true`) blocks
+on the database `host:port` before running, which covers the bundled PostgreSQL not being
+ready yet on a fresh install.
+
+#### Updates (`odoo.update`)
+
+When `odoo.update.enabled: true`, a **`pre-upgrade` hook Job** runs on the next
+`helm upgrade`. It:
+
+1. scales the Odoo deployment (and the cron deployment, if enabled) to **0 replicas**,
+2. optionally serves a maintenance page while the migration runs
+   (`odoo.update.maintenancePage: true`, requires `ingress.enabled`),
+3. runs `odoo -u <modules> -d <db> --stop-after-init`,
+
+after which Helm re-applies the deployment, bringing Odoo back up with the new image — all
+within a single `helm upgrade`.
+
+> [!NOTE]
+> The update Job is a `pre-upgrade` hook, so it runs **only on a `helm upgrade` of an
+> existing release** — it is skipped on the **first install** (including
+> `helm upgrade --install` of a new release, which Helm treats as an install). This is
+> intentional: a fresh database has no installed modules to migrate. First-time setup is
+> handled by the `odoo.init` `post-install` hook instead.
+
+The maintenance page is served **without modifying the ingress**: a temporary maintenance
+pod is created with the same labels the `<release>-nginx` Service selects on, so while Odoo
+is scaled to 0 that Service routes to the maintenance pod, and routes back to Odoo once the
+pod is torn down and Odoo returns.
+
+```yaml
+odoo:
+  update:
+    enabled: true       # set true only for a version bump (causes downtime + migration)
+    modules: all
+    maintenancePage: true
+```
+
+> [!IMPORTANT]
+> `odoo.update.enabled` defaults to `false`. Enable it **only** for the upgrade that bumps
+> the Odoo image/version, then set it back to `false` — leaving it on means a scale-to-0
+> migration runs on **every** `helm upgrade`. The update hook creates a small RBAC
+> (ServiceAccount/Role/RoleBinding) so it can scale the deployments to 0 and wait for their
+> pods to terminate; these are rendered only while `odoo.update.enabled: true`.
+
+The kubectl image used by the update hook is configurable via `odoo.hooks.kubectlImage`
+(default `alpine/kubectl:1.36.1`).
+
 ## Local Setup for development
 
 Create a kind cluster:
@@ -148,6 +214,20 @@ nano /etc/hosts
 172.18.0.2 odoo.local
 ```
 
+Modify the test/local.yaml file and run the helm chart:
+
+```bash
+helm dep up
+helm upgrade odoo . -f test/local.yaml --namespace odoo --create-namespace --install
+```
+
+Cleanup:
+
+```bash
+helm uninstall odoo -n odoo
+kind delete cluster
+```
+
 ## Contributing
 
 Feel free to contribute by making a [pull request](https://github.com/imio/helm-odoo/pull/new/master).
@@ -157,6 +237,10 @@ Please read the official [Helm Contribution Guide](https://github.com/helm/chart
 ## Upgrading
 
 ### To 1.0.0
+
+This is a breaking release. There are two independent migrations to apply to your values.
+
+**1. PostgreSQL configuration split**
 
 The single `postgresql:` section that previously held both the bundled-chart config and
 the database connection settings has been split into two clearly-scoped sections
@@ -168,6 +252,26 @@ database). Update your values as follows:
 - `postgresql.auth.admin_password` → `postgresql.auth.postgresPassword` (bitnami-native key).
 - External-database connection now lives under `externalDatabase.*` (read only when
   `postgresql.enabled: false`).
+
+**2. Init and update moved to Helm hook Jobs**
+
+Database initialization and updates are no longer run inside the main deployment — the old
+`init-db-odoo` init container and the `odoo --update …` command override have been removed
+in favor of [Helm hook Jobs](#database-initialization-and-updates). Notable changes:
+
+- **`odoo.update.enabled` now defaults to `false`** (was `true`). Previously the running
+  Odoo container ran `odoo --update` on every start; now an enabled update is a
+  `pre-upgrade` Job that scales Odoo to 0 and migrates. Enable it only for the upgrade that
+  bumps the Odoo version, then set it back to `false`.
+- `odoo.init.enabled` now drives a `post-install` Job that runs **once** on first install
+  (not on every pod start / per replica).
+- New value groups: `odoo.update.maintenancePage` and `odoo.hooks.*`
+  (`backoffLimit`, `ttlSecondsAfterFinished`, `waitForDb`, `kubectlImage`).
+
+> [!NOTE]
+> The update hook needs permission to scale the deployments to 0. The chart creates a
+> namespaced ServiceAccount/Role/RoleBinding for this automatically, rendered only while
+> `odoo.update.enabled: true`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ without touching the ingress.
 > [!IMPORTANT]
 > Set `odoo.update.enabled` back to `false` after the upgrade — left on, a
 > scale-to-0 migration runs on every `helm upgrade`.
-
 > [!NOTE]
 > **Bundled PostgreSQL + hooks:** Helm cannot deploy a subchart before the parent's
 > `pre-install` hooks, so `postgresql.enabled: true` is not up when the Jobs run. For

--- a/README.md
+++ b/README.md
@@ -101,14 +101,17 @@ You need to have the external-secrets.io operator installed in your cluster. See
 ### Database initialization and updates
 
 Database lifecycle is handled by **Helm hook Jobs** rather than inside the main
-deployment. This keeps a single Job per operation (regardless of replica count) and
-makes sure nothing writes to the database while a migration is running.
+deployment. Both Jobs run on **`pre-install` and `pre-upgrade`**, so they execute
+*before* the Odoo (and cron) deployments are created or re-applied — nothing writes to
+the database while they run, and Odoo never starts against an uninitialised DB. Each Job
+first scales any **running** Odoo/cron to 0 (a no-op on a fresh install, where they don't
+exist yet) and waits for the database to be reachable; afterwards Helm brings the
+deployments up at their normal replica counts.
 
 #### Initialization (`odoo.init`)
 
-When `odoo.init.enabled: true`, a **`post-install` hook Job** runs **once, on the first
-`helm install`**, executing `odoo -i <modules> -d <db> --stop-after-init`. It does not
-re-run on later upgrades or pod restarts.
+When `odoo.init.enabled: true`, the init hook Job runs `odoo -i <modules> -d <db>
+--stop-after-init` at hook-weight `0` (before the update Job).
 
 ```yaml
 odoo:
@@ -117,29 +120,29 @@ odoo:
     modules: base,web   # modules to install on the fresh database
 ```
 
+> [!NOTE]
+> `odoo.init.enabled` is a **one-shot** intent. Set it `true` to initialise the database on
+> install, **or to re-initialise after wiping the DB**: run
+> `helm upgrade ... --set odoo.init.enabled=true` and the init Job scales Odoo/cron to 0,
+> re-runs `odoo -i`, then Helm brings them back up. Set it back to `false` afterwards —
+> left on, every `helm upgrade` re-runs `odoo -i` (a no-op on already-installed modules,
+> but it scales Odoo to 0 for the duration).
+
 An optional `wait-for-db` init container (`odoo.hooks.waitForDb`, default `true`) blocks
-on the database `host:port` before running, which covers the bundled PostgreSQL not being
-ready yet on a fresh install.
+on the database `host:port` before running.
 
 #### Updates (`odoo.update`)
 
-When `odoo.update.enabled: true`, a **`pre-upgrade` hook Job** runs on the next
-`helm upgrade`. It:
+When `odoo.update.enabled: true`, the update hook Job runs at hook-weight `10` (after
+init). It:
 
 1. scales the Odoo deployment (and the cron deployment, if enabled) to **0 replicas**,
 2. optionally serves a maintenance page while the migration runs
    (`odoo.update.maintenancePage: true`, requires `ingress.enabled`),
 3. runs `odoo -u <modules> -d <db> --stop-after-init`,
 
-after which Helm re-applies the deployment, bringing Odoo back up with the new image — all
-within a single `helm upgrade`.
-
-> [!NOTE]
-> The update Job is a `pre-upgrade` hook, so it runs **only on a `helm upgrade` of an
-> existing release** — it is skipped on the **first install** (including
-> `helm upgrade --install` of a new release, which Helm treats as an install). This is
-> intentional: a fresh database has no installed modules to migrate. First-time setup is
-> handled by the `odoo.init` `post-install` hook instead.
+after which Helm re-applies the deployment, bringing Odoo back up with the new image.
+`odoo -u` requires an already-initialised database (use `odoo.init` for a brand-new DB).
 
 The maintenance page is served **without modifying the ingress**: a temporary maintenance
 pod is created with the same labels the `<release>-nginx` Service selects on, so while Odoo
@@ -157,12 +160,30 @@ odoo:
 > [!IMPORTANT]
 > `odoo.update.enabled` defaults to `false`. Enable it **only** for the upgrade that bumps
 > the Odoo image/version, then set it back to `false` — leaving it on means a scale-to-0
-> migration runs on **every** `helm upgrade`. The update hook creates a small RBAC
-> (ServiceAccount/Role/RoleBinding) so it can scale the deployments to 0 and wait for their
-> pods to terminate; these are rendered only while `odoo.update.enabled: true`.
+> migration runs on **every** `helm upgrade`. The init/update hooks share a small RBAC
+> (ServiceAccount/Role/RoleBinding) so they can scale the deployments to 0 and wait for
+> their pods to terminate; it is rendered while `odoo.init.enabled` **or**
+> `odoo.update.enabled` is true.
 
-The kubectl image used by the update hook is configurable via `odoo.hooks.kubectlImage`
+The kubectl image used by the init/update hooks is configurable via `odoo.hooks.kubectlImage`
 (default `alpine/kubectl:1.36.1`).
+
+> [!NOTE]
+> **Bundled PostgreSQL + hooks:** the hooks run at `pre-install`, and Helm cannot deploy a
+> dependency before the parent's pre-install hooks, so the bundled bitnami PostgreSQL
+> (`postgresql.enabled: true`) is not up when they run. To use it together with the hooks
+> (dev/test), run PostgreSQL itself as a pre-install hook via `postgresql.commonAnnotations`
+> (`helm.sh/hook: pre-install` with a weight below `0`) — see `test/local.yaml`. For
+> production, use an external database (`postgresql.enabled: false` + `externalDatabase.*`).
+
+> [!NOTE]
+> **odoo.conf secret + hooks:** because the hooks run at `pre-install`, the secret they mount
+> is provisioned *before* them. The Jobs (and the deployment) always mount `<release>-odoo-conf`:
+> in **generated** mode the chart renders it as a `pre-install,pre-upgrade` hook (so it's a Helm
+> hook even without init/update — recreated each upgrade, not shown in `helm get manifest`/rollback;
+> harmless because kubelet re-mounts); in **existingSecret** mode it pre-exists; in **externalsecrets**
+> mode the `ExternalSecret` is also a pre-install hook, so the operator syncs the secret during
+> pre-install and the Job's mount retries until it appears (the operator must sync within `--timeout`).
 
 ## Local Setup for development
 
@@ -261,10 +282,11 @@ in favor of [Helm hook Jobs](#database-initialization-and-updates). Notable chan
 
 - **`odoo.update.enabled` now defaults to `false`** (was `true`). Previously the running
   Odoo container ran `odoo --update` on every start; now an enabled update is a
-  `pre-upgrade` Job that scales Odoo to 0 and migrates. Enable it only for the upgrade that
-  bumps the Odoo version, then set it back to `false`.
-- `odoo.init.enabled` now drives a `post-install` Job that runs **once** on first install
-  (not on every pod start / per replica).
+  `pre-install,pre-upgrade` hook Job that scales Odoo to 0 and migrates. Enable it only for
+  the upgrade that bumps the Odoo version, then set it back to `false`.
+- `odoo.init.enabled` now drives a `pre-install,pre-upgrade` hook Job (a single Job, not
+  per-replica / per-restart) that runs before Odoo starts; it can be re-run to
+  re-initialise a wiped database via `helm upgrade`.
 - New value groups: `odoo.update.maintenancePage` and `odoo.hooks.*`
   (`backoffLimit`, `ttlSecondsAfterFinished`, `waitForDb`, `kubectlImage`).
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -177,11 +177,12 @@ Volumes for the init/update hook Jobs: the odoo.conf secret. Call with root cont
 {{- define "..hookVolumes" -}}
 - name: {{ include "..fullname" . }}-odoo-conf
   secret:
-    {{- /* All backends expose <fullname>-odoo-conf at/before hook time: generated
-        renders it as a pre-install hook, existingSecret pre-exists, externalsecrets
-        is synced by the operator (its ExternalSecret is a pre-install hook) and the
-        Job's mount retries until it appears. */}}
-    secretName: "{{ include "..fullname" . }}-odoo-conf"
+    {{- /* existingSecret: the user's pre-existing <fullname>-odoo-conf is mounted
+        directly (it already exists at hook time). generated/externalsecrets: the
+        Jobs mount the dedicated pre-install hook copy <fullname>-odoo-conf-hook —
+        the runtime <fullname>-odoo-conf is a NORMAL resource, applied only after
+        pre-install hooks, so it is not yet available to the Jobs. */}}
+    secretName: "{{ include "..fullname" . }}-odoo-conf{{ if not .Values.existingSecret.enabled }}-hook{{ end }}"
 {{- end }}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -177,5 +177,65 @@ Volumes for the init/update hook Jobs: the odoo.conf secret. Call with root cont
 {{- define "..hookVolumes" -}}
 - name: {{ include "..fullname" . }}-odoo-conf
   secret:
+    {{- /* All backends expose <fullname>-odoo-conf at/before hook time: generated
+        renders it as a pre-install hook, existingSecret pre-exists, externalsecrets
+        is synced by the operator (its ExternalSecret is a pre-install hook) and the
+        Job's mount retries until it appears. */}}
     secretName: "{{ include "..fullname" . }}-odoo-conf"
+{{- end }}
+
+{{/*
+"prepare" initContainer for the init/update hook Jobs. Scales the Odoo and cron
+deployments to 0 and waits for their pods to terminate — but only if they already
+exist (on pre-install they do not yet, so it is a graceful no-op; on pre-upgrade
+it quiesces the running pods so nothing writes to the DB while the hook runs).
+Requires the <fullname>-hook ServiceAccount/RBAC. Render under `initContainers:`
+with nindent 8. Call with the root context.
+*/}}
+{{- define "..hookScaleDownInitContainer" -}}
+{{- $fullName := include "..fullname" . -}}
+{{- $selector := printf "app.kubernetes.io/instance=%s,app.kubernetes.io/name=%s" .Release.Name (include "..name" .) -}}
+- name: prepare
+  image: "{{ .Values.odoo.hooks.kubectlImage }}"
+  command:
+    - /bin/sh
+    - -c
+    - |
+      set -e
+      # Scale a deployment to 0 and wait for its pods to go away, but only if it
+      # already exists. A deployment being created by this same install/upgrade
+      # (e.g. cron enabled for the first time) does not exist yet at hook time.
+      scale_down() {
+        if kubectl get deployment "$1" >/dev/null 2>&1; then
+          echo "scaling down $1"
+          kubectl scale deployment "$1" --replicas=0
+          if kubectl get pods -l "$2" --no-headers -o name | grep -q .; then
+            kubectl wait --for=delete pod -l "$2" --timeout=300s
+          fi
+        else
+          echo "deployment $1 not found, skipping"
+        fi
+      }
+      scale_down {{ $fullName }} "{{ $selector }},app.kubernetes.io/component=server"
+      scale_down {{ $fullName }}-cron "{{ $selector }},app.kubernetes.io/component=cron"
+{{- end }}
+
+{{/*
+"wait-for-db" initContainer for the init/update hook Jobs: blocks until the
+database host:port accepts a TCP connection, so `odoo -i`/`odoo -u` never runs
+before the DB is reachable. Render under `initContainers:` with nindent 8; the
+caller gates on .Values.odoo.hooks.waitForDb. Call with the root context.
+*/}}
+{{- define "..hookWaitForDbInitContainer" -}}
+- name: wait-for-db
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+  command:
+    - /bin/bash
+    - -c
+    - |
+      until bash -c "echo > /dev/tcp/{{ include "..dbHost" . }}/{{ include "..dbPort" . }}" 2>/dev/null; do
+        echo "waiting for database {{ include "..dbHost" . }}:{{ include "..dbPort" . }}..."
+        sleep 2
+      done
+      echo "database is reachable"
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -145,3 +145,37 @@ max_cron_threads = 0
 max_cron_threads = {{ .Values.odoo.max_cron_threads | int }}
 {{- end }}
 {{- end }}
+
+{{/*
+Shared spec for the Odoo init/update hook Job containers.
+Renders image, pull policy, the odoo.conf mount and extraEnv/extraEnvFrom — but
+NOT name or command (each Job sets those). Filestore (PVC) is intentionally not
+mounted: the hooks only touch the database, and skipping the RWO volume avoids
+contention with the running Odoo deployment. Call with the root context.
+*/}}
+{{- define "..hookOdooContainer" -}}
+image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+imagePullPolicy: {{ .Values.image.pullPolicy }}
+volumeMounts:
+  - name: {{ include "..fullname" . }}-odoo-conf
+    mountPath: /etc/odoo/odoo.conf
+    subPath: odoo.conf
+    readOnly: true
+{{- if .Values.extraEnv }}
+env:
+{{- toYaml .Values.extraEnv | nindent 2 }}
+{{- end }}
+{{- if .Values.extraEnvFrom }}
+envFrom:
+{{- toYaml .Values.extraEnvFrom | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Volumes for the init/update hook Jobs: the odoo.conf secret. Call with root context.
+*/}}
+{{- define "..hookVolumes" -}}
+- name: {{ include "..fullname" . }}-odoo-conf
+  secret:
+    secretName: "{{ include "..fullname" . }}-odoo-conf"
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,29 +34,9 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
-      {{- if or .Values.odoo.init.enabled .Values.extraInitContainers }}
+      {{- with .Values.extraInitContainers }}
       initContainers:
-        {{- if .Values.odoo.init.enabled }}
-        - name: init-db-odoo
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ["/bin/bash", "-c", 'odoo -i {{ .Values.odoo.init.modules }} -d {{ include "..dbName" . }} --stop-after-init']
-          volumeMounts:
-            - name: {{ include "..fullname" . }}-odoo-conf
-              mountPath: /etc/odoo/odoo.conf
-              subPath: odoo.conf
-              readOnly: true
-          {{- if .Values.extraEnv }}
-          env:
-            {{- toYaml .Values.extraEnv | nindent 12 }}
-          {{- end }}
-          {{- if .Values.extraEnvFrom }}
-          envFrom:
-            {{- toYaml .Values.extraEnvFrom | nindent 12 }}
-          {{- end }}
-        {{- end }}
-        {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
       {{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
@@ -82,9 +62,6 @@ spec:
               subPath: nginx.conf
         - name: {{ include "..fullname" . }}-service
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-      {{- if .Values.odoo.update.enabled }}
-          command: ["/bin/bash", "-c", 'odoo --update {{ .Values.odoo.update.modules }} -d {{ include "..dbName" . }}']
-      {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: odoo-http

--- a/templates/externalsecrets.yaml
+++ b/templates/externalsecrets.yaml
@@ -31,16 +31,11 @@ spec:
       property: postgresql-admin-password
 ---
 {{- end }}
+{{- $odooConf := include "..odooConf" (dict "Values" .Values "dbHost" (include "..dbHost" .) "dbPort" (include "..dbPort" .) "dbName" (include "..dbName" .) "dbUser" (include "..dbUser" .) "dbPassword" "{{ .postgresqlPassword }}" "adminPasswd" "{{ .odooAdminPasswd }}") -}}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ include "..fullname" . }}-odoo-conf-secret
-  # Hooked (see above): the operator syncs <fullname>-odoo-conf during pre-install
-  # so the init/update Jobs can mount it (kubelet retries the mount until synced).
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-15"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   secretStoreRef:
     name: {{ .Values.externalsecrets.secretStoreRef.name }}
@@ -54,7 +49,7 @@ spec:
         labels: {}
       data:
         odoo.conf: |
-{{ include "..odooConf" (dict "Values" .Values "dbHost" (include "..dbHost" .) "dbPort" (include "..dbPort" .) "dbName" (include "..dbName" .) "dbUser" (include "..dbUser" .) "dbPassword" "{{ .postgresqlPassword }}" "adminPasswd" "{{ .odooAdminPasswd }}") | indent 10 }}
+{{ $odooConf | indent 10 }}
   data:
   - secretKey: postgresqlPassword
     remoteRef:
@@ -64,4 +59,42 @@ spec:
     remoteRef:
       key: {{ .Values.externalsecrets.odooKey }}
       property: odoo-admin-passwd
+{{- if or .Values.odoo.init.enabled .Values.odoo.update.enabled }}
+---
+# Hook copy for the init/update Jobs. Rendered as a pre-install/pre-upgrade hook so
+# the operator syncs <fullname>-odoo-conf-hook during the pre-install phase — before
+# the Jobs run; the Job's mount then retries (kubelet) until it appears. Gated on
+# init/update — only needed when a Job actually runs.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "..fullname" . }}-odoo-conf-hook-secret
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  secretStoreRef:
+    name: {{ .Values.externalsecrets.secretStoreRef.name }}
+    kind: SecretStore
+  target:
+    name: {{ include "..fullname" . }}-odoo-conf-hook
+    template:
+      type: Opaque
+      engineVersion: v2
+      metadata:
+        labels: {}
+      data:
+        odoo.conf: |
+{{ $odooConf | indent 10 }}
+  data:
+  - secretKey: postgresqlPassword
+    remoteRef:
+      key: {{ .Values.externalsecrets.odooKey }}
+      property: postgresql-password
+  - secretKey: odooAdminPasswd
+    remoteRef:
+      key: {{ .Values.externalsecrets.odooKey }}
+      property: odoo-admin-passwd
+{{- end }}
 {{- end }}

--- a/templates/externalsecrets.yaml
+++ b/templates/externalsecrets.yaml
@@ -4,6 +4,13 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ include "..fullname" . }}-postgresql-secret
+  # Provision as a pre-install/pre-upgrade hook so the operator syncs the target
+  # Secret during the pre-install phase — before the init/update hook Jobs run.
+  # The Jobs' mount waits (kubelet retries) until the synced Secret appears.
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   secretStoreRef:
     name: {{ .Values.externalsecrets.secretStoreRef.name }}
@@ -28,6 +35,12 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ include "..fullname" . }}-odoo-conf-secret
+  # Hooked (see above): the operator syncs <fullname>-odoo-conf during pre-install
+  # so the init/update Jobs can mount it (kubelet retries the mount until synced).
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   secretStoreRef:
     name: {{ .Values.externalsecrets.secretStoreRef.name }}

--- a/templates/hooks/job-init.yaml
+++ b/templates/hooks/job-init.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.odoo.init.enabled }}
 ---
-# Database initialisation, run once on first install (Helm post-install hook).
-# Replaces the old init-db-odoo initContainer: a single Job regardless of the
-# number of replicas, and it does not re-run on every pod start.
+# Database initialisation (Helm pre-install + pre-upgrade hook). Runs `odoo -i`
+# before the Odoo/cron deployments are (re)applied, so they never start against
+# an uninitialised DB. A lower hook-weight than the update Job (0 < 10), so when
+# both are enabled init completes first. Its `prepare` initContainer scales any
+# running Odoo/cron to 0 first (no-op on a fresh install), so re-init after a DB
+# wipe is `helm upgrade` with odoo.init.enabled=true. Treat init.enabled as a
+# one-shot intent (set back to false after install/re-init).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -11,7 +15,7 @@ metadata:
     {{- include "..labels" . | nindent 4 }}
     app.kubernetes.io/component: init
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
@@ -24,26 +28,18 @@ spec:
         app.kubernetes.io/component: init
     spec:
       restartPolicy: Never
+      serviceAccountName: {{ include "..fullname" . }}-hook
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      {{- if .Values.odoo.hooks.waitForDb }}
       initContainers:
-        - name: wait-for-db
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command:
-            - /bin/bash
-            - -c
-            - |
-              until bash -c "echo > /dev/tcp/{{ include "..dbHost" . }}/{{ include "..dbPort" . }}" 2>/dev/null; do
-                echo "waiting for database {{ include "..dbHost" . }}:{{ include "..dbPort" . }}..."
-                sleep 2
-              done
-              echo "database is reachable"
-      {{- end }}
+        {{- include "..hookScaleDownInitContainer" . | nindent 8 }}
+        {{- if .Values.odoo.hooks.waitForDb }}
+        {{- include "..hookWaitForDbInitContainer" . | nindent 8 }}
+        {{- end }}
       containers:
         - name: odoo-init
           {{- include "..hookOdooContainer" . | nindent 10 }}

--- a/templates/hooks/job-init.yaml
+++ b/templates/hooks/job-init.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.odoo.init.enabled }}
+---
+# Database initialisation, run once on first install (Helm post-install hook).
+# Replaces the old init-db-odoo initContainer: a single Job regardless of the
+# number of replicas, and it does not re-run on every pod start.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "..fullname" . }}-init
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: init
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: {{ .Values.odoo.hooks.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.odoo.hooks.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "..selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: init
+    spec:
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
+      {{- if .Values.odoo.hooks.waitForDb }}
+      initContainers:
+        - name: wait-for-db
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command:
+            - /bin/bash
+            - -c
+            - |
+              until bash -c "echo > /dev/tcp/{{ include "..dbHost" . }}/{{ include "..dbPort" . }}" 2>/dev/null; do
+                echo "waiting for database {{ include "..dbHost" . }}:{{ include "..dbPort" . }}..."
+                sleep 2
+              done
+              echo "database is reachable"
+      {{- end }}
+      containers:
+        - name: odoo-init
+          {{- include "..hookOdooContainer" . | nindent 10 }}
+          command:
+            - /bin/bash
+            - -c
+            - odoo -i {{ .Values.odoo.init.modules }} -d {{ include "..dbName" . }} --stop-after-init
+      volumes:
+        {{- include "..hookVolumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/templates/hooks/job-update.yaml
+++ b/templates/hooks/job-update.yaml
@@ -1,14 +1,16 @@
 {{- if .Values.odoo.update.enabled }}
 {{- $fullName := include "..fullname" . -}}
-{{- $selector := printf "app.kubernetes.io/instance=%s,app.kubernetes.io/name=%s" .Release.Name (include "..name" .) -}}
 ---
-# Module/version update, run on `helm upgrade` (Helm pre-upgrade hook).
-# Scales Odoo (and cron) to 0 so nothing writes to the DB during the migration,
-# then runs `odoo -u <modules> --stop-after-init`. Helm then re-applies the
-# deployment, bringing Odoo back up with the new image. While Odoo is at 0, the
-# maintenance-page hook pod (see maintenance-hook.yaml) carries the same labels
-# as the Odoo pods, so the existing nginx Service routes to it automatically —
-# the ingress is never modified.
+# Module/version update (Helm pre-install + pre-upgrade hook). Runs at a higher
+# hook-weight than init (10 > 0), so when both are enabled init runs first.
+# Its `prepare` initContainer scales Odoo (and cron) to 0 so nothing writes to
+# the DB during the migration, then runs `odoo -u <modules> --stop-after-init`.
+# Helm then (re-)applies the deployment, bringing Odoo back up with the new
+# image. While Odoo is at 0, the maintenance-page hook pod (see
+# maintenance-hook.yaml) carries the same labels as the Odoo pods, so the
+# existing nginx Service routes to it automatically — the ingress is never
+# modified. On pre-install the deployments don't exist yet, so `prepare` is a
+# no-op and Helm simply starts Odoo after the hook.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -17,8 +19,8 @@ metadata:
     {{- include "..labels" . | nindent 4 }}
     app.kubernetes.io/component: update
   annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: {{ .Values.odoo.hooks.backoffLimit }}
@@ -38,30 +40,10 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-        - name: prepare
-          image: "{{ .Values.odoo.hooks.kubectlImage }}"
-          command:
-            - /bin/sh
-            - -c
-            - |
-              set -e
-              # Scale a deployment to 0 and wait for its pods to go away, but
-              # only if it already exists. A deployment that is being created by
-              # this same `helm upgrade` (e.g. cron enabled for the first time)
-              # does not exist yet at pre-upgrade hook time.
-              scale_down() {
-                if kubectl get deployment "$1" >/dev/null 2>&1; then
-                  echo "scaling down $1"
-                  kubectl scale deployment "$1" --replicas=0
-                  if kubectl get pods -l "$2" --no-headers -o name | grep -q .; then
-                    kubectl wait --for=delete pod -l "$2" --timeout=300s
-                  fi
-                else
-                  echo "deployment $1 not found, skipping"
-                fi
-              }
-              scale_down {{ $fullName }} "{{ $selector }},app.kubernetes.io/component=server"
-              scale_down {{ $fullName }}-cron "{{ $selector }},app.kubernetes.io/component=cron"
+        {{- include "..hookScaleDownInitContainer" . | nindent 8 }}
+        {{- if .Values.odoo.hooks.waitForDb }}
+        {{- include "..hookWaitForDbInitContainer" . | nindent 8 }}
+        {{- end }}
       containers:
         - name: odoo-update
           {{- include "..hookOdooContainer" . | nindent 10 }}

--- a/templates/hooks/job-update.yaml
+++ b/templates/hooks/job-update.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.odoo.update.enabled }}
+{{- $fullName := include "..fullname" . -}}
+{{- $selector := printf "app.kubernetes.io/instance=%s,app.kubernetes.io/name=%s" .Release.Name (include "..name" .) -}}
+---
+# Module/version update, run on `helm upgrade` (Helm pre-upgrade hook).
+# Scales Odoo (and cron) to 0 so nothing writes to the DB during the migration,
+# then runs `odoo -u <modules> --stop-after-init`. Helm then re-applies the
+# deployment, bringing Odoo back up with the new image. While Odoo is at 0, the
+# maintenance-page hook pod (see maintenance-hook.yaml) carries the same labels
+# as the Odoo pods, so the existing nginx Service routes to it automatically —
+# the ingress is never modified.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-update
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: update
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: {{ .Values.odoo.hooks.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.odoo.hooks.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "..selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: update
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $fullName }}-hook
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
+      initContainers:
+        - name: prepare
+          image: "{{ .Values.odoo.hooks.kubectlImage }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              # Scale a deployment to 0 and wait for its pods to go away, but
+              # only if it already exists. A deployment that is being created by
+              # this same `helm upgrade` (e.g. cron enabled for the first time)
+              # does not exist yet at pre-upgrade hook time.
+              scale_down() {
+                if kubectl get deployment "$1" >/dev/null 2>&1; then
+                  echo "scaling down $1"
+                  kubectl scale deployment "$1" --replicas=0
+                  kubectl wait --for=delete pod -l "$2" --timeout=300s || true
+                else
+                  echo "deployment $1 not found, skipping"
+                fi
+              }
+              scale_down {{ $fullName }} "{{ $selector }},app.kubernetes.io/component=server"
+              {{- if .Values.cron.enabled }}
+              scale_down {{ $fullName }}-cron "{{ $selector }},app.kubernetes.io/component=cron"
+              {{- end }}
+      containers:
+        - name: odoo-update
+          {{- include "..hookOdooContainer" . | nindent 10 }}
+          command:
+            - /bin/bash
+            - -c
+            - odoo -u {{ .Values.odoo.update.modules }} -d {{ include "..dbName" . }} --stop-after-init
+      volumes:
+        {{- include "..hookVolumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/templates/hooks/job-update.yaml
+++ b/templates/hooks/job-update.yaml
@@ -53,15 +53,15 @@ spec:
                 if kubectl get deployment "$1" >/dev/null 2>&1; then
                   echo "scaling down $1"
                   kubectl scale deployment "$1" --replicas=0
-                  kubectl wait --for=delete pod -l "$2" --timeout=300s || true
+                  if kubectl get pods -l "$2" --no-headers -o name | grep -q .; then
+                    kubectl wait --for=delete pod -l "$2" --timeout=300s
+                  fi
                 else
                   echo "deployment $1 not found, skipping"
                 fi
               }
               scale_down {{ $fullName }} "{{ $selector }},app.kubernetes.io/component=server"
-              {{- if .Values.cron.enabled }}
               scale_down {{ $fullName }}-cron "{{ $selector }},app.kubernetes.io/component=cron"
-              {{- end }}
       containers:
         - name: odoo-update
           {{- include "..hookOdooContainer" . | nindent 10 }}

--- a/templates/hooks/maintenance-hook.yaml
+++ b/templates/hooks/maintenance-hook.yaml
@@ -1,0 +1,69 @@
+{{- if and .Values.odoo.update.enabled .Values.odoo.update.maintenancePage .Values.ingress.enabled (not .Values.maintenance.enabled) }}
+{{- $fullName := include "..fullname" . -}}
+---
+# Maintenance page served during an update migration. Rendered as a pre-upgrade
+# hook (created before the update Job scales Odoo down, removed once the update
+# succeeds). The pod deliberately carries the chart's selectorLabels — the same
+# labels the {{ $fullName }}-nginx Service selects on — and exposes a port named
+# `nginx-http`. While the Odoo deployment is scaled to 0, that Service therefore
+# routes to this maintenance pod, so the ingress is never touched (and never
+# needs reverting). Reuses the maintenance nginx config/HTML ConfigMaps that the
+# chart already renders. Only used when maintenance.enabled is false.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-maintenance-page
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: maintenance
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "..selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: maintenance
+  template:
+    metadata:
+      {{- with .Values.maintenance.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "..selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: maintenance
+    spec:
+      {{- if .Values.nginx.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.nginx.image.pullSecret }}
+      {{- end }}
+      containers:
+      - name: nginx
+        image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+        ports:
+        # Named nginx-http so the {{ $fullName }}-nginx Service (targetPort:
+        # nginx-http) routes here while Odoo is scaled to 0.
+        - name: nginx-http
+          containerPort: 80
+          protocol: TCP
+        volumeMounts:
+        - name: {{ $fullName }}-config-volume
+          mountPath: /usr/share/nginx/html/maintenance/
+        - name: {{ $fullName }}-default-config-volume
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: default.conf
+      volumes:
+        - name: {{ $fullName }}-config-volume
+          configMap:
+            {{- if ne .Values.maintenance.customTemplate.name "" }}
+            name: {{ .Values.maintenance.customTemplate.name }}
+            {{- else }}
+            name: {{ $fullName }}-maintenance-page
+            {{- end }}
+        - name: {{ $fullName }}-default-config-volume
+          configMap:
+            name: {{ $fullName }}-default-conf
+{{- end }}

--- a/templates/hooks/maintenance-hook.yaml
+++ b/templates/hooks/maintenance-hook.yaml
@@ -1,9 +1,9 @@
-{{- if and .Values.odoo.update.enabled .Values.odoo.update.maintenancePage .Values.ingress.enabled (not .Values.maintenance.enabled) }}
+{{- if and (or .Values.odoo.update.enabled .Values.odoo.init.enabled) .Values.odoo.update.maintenancePage .Values.ingress.enabled (not .Values.maintenance.enabled) }}
 {{- $fullName := include "..fullname" . -}}
 ---
-# Maintenance page served during an update migration. Rendered as a pre-upgrade
-# hook (created before the update Job scales Odoo down, removed once the update
-# succeeds). The pod deliberately carries the chart's selectorLabels — the same
+# Maintenance page served during an update or re-init migration. Rendered as a
+# pre-upgrade hook (created before the init/update Job scales Odoo down, removed
+# once the hook succeeds). The pod deliberately carries the chart's selectorLabels — the same
 # labels the {{ $fullName }}-nginx Service selects on — and exposes a port named
 # `nginx-http`. While the Odoo deployment is scaled to 0, that Service therefore
 # routes to this maintenance pod, so the ingress is never touched (and never
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/component: maintenance
   annotations:
     "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   replicas: 1

--- a/templates/hooks/rbac.yaml
+++ b/templates/hooks/rbac.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.odoo.update.enabled }}
+{{- $fullName := include "..fullname" . -}}
+---
+# RBAC for the update hook Job: lets it scale the Odoo/cron deployments to 0 and
+# wait for their pods to terminate during the migration. Created before the
+# update Job (lower hook-weight).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-hook
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-hook
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-hook
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}-hook
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-hook
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/templates/hooks/rbac.yaml
+++ b/templates/hooks/rbac.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.odoo.update.enabled }}
+{{- if or .Values.odoo.init.enabled .Values.odoo.update.enabled }}
 {{- $fullName := include "..fullname" . -}}
 ---
-# RBAC for the update hook Job: lets it scale the Odoo/cron deployments to 0 and
-# wait for their pods to terminate during the migration. Created before the
-# update Job (lower hook-weight).
+# RBAC for the init/update hook Jobs: lets their `prepare` initContainer scale
+# the Odoo/cron deployments to 0 and wait for their pods to terminate. Created
+# before the init/update Jobs (lower hook-weight), on both install and upgrade.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,8 +11,8 @@ metadata:
   labels:
     {{- include "..labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,8 +22,8 @@ metadata:
   labels:
     {{- include "..labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
   - apiGroups: ["apps"]
@@ -43,8 +43,8 @@ metadata:
   labels:
     {{- include "..labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -6,9 +6,19 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ include "..fullname" . }}-odoo-conf"
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+  # The init/update Jobs run as pre-install/pre-upgrade hooks and mount this
+  # secret, so it must exist before the chart's normal resources. Provision it
+  # as a hook too (weight below the init Job at 0). It is a hook UNCONDITIONALLY
+  # (not gated on init/update): a secret that flips hook<->normal when the hooks
+  # are toggled trips Helm's ownership check ("invalid ownership metadata").
+  # before-hook-creation is required — Helm Creates hooks, so a re-run on the
+  # next upgrade would otherwise fail with "already exists".
   annotations:
-    labels:
-        {{- include "..labels" . | nindent 4 }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 stringData:
   odoo.conf: |

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -2,19 +2,28 @@
 {{- fail "existingSecret and externalsecrets cannot both be enabled. Choose one secret backend." }}
 {{- end }}
 {{- if and (not .Values.existingSecret.enabled) (not .Values.externalsecrets.enabled) }}
+{{- $odooConf := include "..odooConf" (dict "Values" .Values "dbHost" (include "..dbHost" .) "dbPort" (include "..dbPort" .) "dbName" (include "..dbName" .) "dbUser" (include "..dbUser" .) "dbPassword" (include "..dbPassword" .) "adminPasswd" .Values.odoo.admin_passwd) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ include "..fullname" . }}-odoo-conf"
   labels:
     {{- include "..labels" . | nindent 4 }}
-  # The init/update Jobs run as pre-install/pre-upgrade hooks and mount this
-  # secret, so it must exist before the chart's normal resources. Provision it
-  # as a hook too (weight below the init Job at 0). It is a hook UNCONDITIONALLY
-  # (not gated on init/update): a secret that flips hook<->normal when the hooks
-  # are toggled trips Helm's ownership check ("invalid ownership metadata").
-  # before-hook-creation is required — Helm Creates hooks, so a re-run on the
-  # next upgrade would otherwise fail with "already exists".
+type: Opaque
+stringData:
+  odoo.conf: |
+{{ $odooConf | indent 4 }}
+{{- if or .Values.odoo.init.enabled .Values.odoo.update.enabled }}
+---
+# Hook copy of odoo.conf for the init/update Jobs. Those Jobs run as
+# pre-install/pre-upgrade hooks, so the secret they mount must also exist before
+# the chart's normal resources.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "..fullname" . }}-odoo-conf-hook"
+  labels:
+    {{- include "..labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-15"
@@ -22,5 +31,6 @@ metadata:
 type: Opaque
 stringData:
   odoo.conf: |
-{{ include "..odooConf" (dict "Values" .Values "dbHost" (include "..dbHost" .) "dbPort" (include "..dbPort" .) "dbName" (include "..dbName" .) "dbUser" (include "..dbUser" .) "dbPassword" (include "..dbPassword" .) "adminPasswd" .Values.odoo.admin_passwd) | indent 4 }}
+{{ $odooConf | indent 4 }}
+{{- end }}
 {{- end }}

--- a/test/local.yaml
+++ b/test/local.yaml
@@ -110,6 +110,15 @@ externalDatabase:
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 postgresql:
   enabled: true
+  # The Odoo init/update hooks run at pre-install and wait for the DB. Helm has
+  # no way to deploy a subchart before the parent's pre-install hooks, so run
+  # the bundled PostgreSQL as a pre-install hook itself (lower weight than the
+  # init hook at 0) — Helm waits for it Ready first. Dev/test only; pairs with
+  # the ephemeral storage below. Production should use an external DB instead
+  # (postgresql.enabled: false + externalDatabase.*).
+  commonAnnotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-20"
   auth:
     # Database name should be false if you are using a multi-tenant setup
     # In this case, we are using the dbfilter option in the odoo section

--- a/test/local.yaml
+++ b/test/local.yaml
@@ -28,13 +28,6 @@ nginx:
     ## Optionally specify an imagePullSecret.
     ## Secret must be manually created in the namespace.
     ## pullSecret:
-  # Serve the maintenance page from the sidecar whenever the Odoo upstream is
-  # unavailable (e.g. while Odoo is starting up after an update, or during a
-  # restart). When enabled, pod readiness is driven by the nginx sidecar
-  # (/healthz) and the Odoo container's readinessProbe is dropped, so the pod
-  # stays a Service endpoint while Odoo boots and nginx can show the page
-  # instead of the ingress returning a bare 503.
-  maintenanceFallback: true
   resources: {}
   livenessProbe:
     httpGet:

--- a/test/local.yaml
+++ b/test/local.yaml
@@ -28,6 +28,13 @@ nginx:
     ## Optionally specify an imagePullSecret.
     ## Secret must be manually created in the namespace.
     ## pullSecret:
+  # Serve the maintenance page from the sidecar whenever the Odoo upstream is
+  # unavailable (e.g. while Odoo is starting up after an update, or during a
+  # restart). When enabled, pod readiness is driven by the nginx sidecar
+  # (/healthz) and the Odoo container's readinessProbe is dropped, so the pod
+  # stays a Service endpoint while Odoo boots and nginx can show the page
+  # instead of the ingress returning a bare 503.
+  maintenanceFallback: true
   resources: {}
   livenessProbe:
     httpGet:
@@ -47,8 +54,14 @@ odoo:
     enabled: true
     modules: base,web
   update:
+    # Set true (with a new image.tag) to exercise the pre-upgrade update hook.
     enabled: true
     modules: all
+    maintenancePage: true
+  hooks:
+    backoffLimit: 1
+    waitForDb: true
+    kubectlImage: "alpine/kubectl:1.36.1"
   server_wide_modules: base,web
   admin_passwd: "mySecuredPassword"
   proxy_mode: "True"
@@ -74,7 +87,7 @@ odoo:
   log_handler: ":INFO"
 
 cron:
-  enabled: false
+  enabled: true
   replicaCount: 1
   strategy: Recreate
   max_cron_threads: 2

--- a/values.yaml
+++ b/values.yaml
@@ -56,23 +56,31 @@ nginx:
 
 # Odoo application configuration
 odoo:
-  # Database initialisation. When enabled, a Job runs once as a Helm
-  # post-install hook (first install only): `odoo -i <modules> -d <db> --stop-after-init`.
+  # Database initialisation. When enabled, a Job runs as a Helm pre-install AND
+  # pre-upgrade hook: its `prepare` initContainer scales any running Odoo/cron
+  # to 0, it waits for the DB, then runs `odoo -i <modules> -d <db>
+  # --stop-after-init` BEFORE the Odoo deployment is (re)applied — so Odoo never
+  # starts against an uninitialised DB. Runs at a lower hook-weight than update,
+  # so init completes first when both are enabled.
+  # Treat `enabled` as a ONE-SHOT intent: set true to initialise on install, or
+  # to re-initialise after trashing the DB (`helm upgrade` with init.enabled=true),
+  # then set it back to false. Left on, every `helm upgrade` re-runs `odoo -i`
+  # (a no-op on already-installed modules, but it scales Odoo to 0 meanwhile).
   init:
     enabled: false
     modules: base,web
-  # Module/version update. When enabled, a Job runs as a Helm pre-upgrade hook
-  # on the next `helm upgrade`: it scales Odoo (and cron) to 0, runs
-  # `odoo -u <modules> -d <db> --stop-after-init`, then Helm brings the
+  # Module/version update. When enabled, a Job runs as a Helm pre-install AND
+  # pre-upgrade hook, at a HIGHER weight than init (so init runs first): its
+  # `prepare` initContainer scales Odoo (and cron) to 0, it waits for the DB,
+  # runs `odoo -u <modules> -d <db> --stop-after-init`, then Helm brings the
   # deployment back up with the new image. Set true only for a version bump —
-  # leaving it on means downtime + migration on every upgrade.
-  # Runs only on `helm upgrade` of an existing release; it is skipped on the first
-  # install (a fresh DB is initialized by odoo.init, not updated).
+  # leaving it on means downtime + migration on every upgrade. `odoo -u` needs
+  # an already-initialised DB (use odoo.init for a brand-new database).
   update:
     enabled: false
     modules: all
     # Serve the maintenance page (via the existing maintenance nginx) while the
-    # update migration runs. Requires ingress.enabled. Ignored if maintenance.enabled.
+    # update/re-init migration runs. Requires ingress.enabled. Ignored if maintenance.enabled.
     maintenancePage: true
   # Shared settings for the init/update hook Jobs
   hooks:
@@ -80,9 +88,9 @@ odoo:
     backoffLimit: 1
     # Auto-clean finished hook Jobs after this many seconds
     ttlSecondsAfterFinished: 86400
-    # init: block on the DB host:port (TCP) before running `odoo -i`
+    # init/update: block on the DB host:port (TCP) before running odoo
     waitForDb: true
-    # Image used by the update hook to scale the deployments down
+    # Image used by the init/update hooks to scale the deployments down
     kubectlImage: "alpine/kubectl:1.36.1"
   server_wide_modules: base,web
   # admin_passwd: managed by external secrets
@@ -161,9 +169,19 @@ externalDatabase:
 # Set enabled: false to use an external database (configure externalDatabase above).
 # Passwords can be set inline via auth.password/auth.postgresPassword, OR supplied
 # through auth.existingSecret (bitnami-native).
+#
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 postgresql:
   enabled: true
+  # The Odoo init/update hooks run at pre-install and wait for the DB. Helm has
+  # no way to deploy a subchart before the parent's pre-install hooks, so run
+  # the bundled PostgreSQL as a pre-install hook itself (lower weight than the
+  # init hook at 0) — Helm waits for it Ready first. Dev/test only; pairs with
+  # the ephemeral storage below. Production should use an external DB instead
+  # (postgresql.enabled: false + externalDatabase.*).
+  commonAnnotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-20"
   global:
     security:
       allowInsecureImages: true
@@ -192,7 +210,11 @@ postgresql:
 existingSecret:
   enabled: false
 
-# Use external-secrets.io for Odoo configuration instead of generating one
+# Use external-secrets.io for Odoo configuration instead of generating one.
+# Works with odoo.init/odoo.update: the ExternalSecret is rendered as a
+# pre-install/pre-upgrade hook so the operator syncs the odoo.conf secret during
+# the pre-install phase; the hook Job's mount then retries until it appears (the
+# operator must sync within helm --timeout).
 externalsecrets:
   enabled: false
   secretStoreRef:

--- a/values.yaml
+++ b/values.yaml
@@ -56,12 +56,34 @@ nginx:
 
 # Odoo application configuration
 odoo:
+  # Database initialisation. When enabled, a Job runs once as a Helm
+  # post-install hook (first install only): `odoo -i <modules> -d <db> --stop-after-init`.
   init:
     enabled: false
     modules: base,web
+  # Module/version update. When enabled, a Job runs as a Helm pre-upgrade hook
+  # on the next `helm upgrade`: it scales Odoo (and cron) to 0, runs
+  # `odoo -u <modules> -d <db> --stop-after-init`, then Helm brings the
+  # deployment back up with the new image. Set true only for a version bump —
+  # leaving it on means downtime + migration on every upgrade.
+  # Runs only on `helm upgrade` of an existing release; it is skipped on the first
+  # install (a fresh DB is initialized by odoo.init, not updated).
   update:
-    enabled: true
+    enabled: false
     modules: all
+    # Serve the maintenance page (via the existing maintenance nginx) while the
+    # update migration runs. Requires ingress.enabled. Ignored if maintenance.enabled.
+    maintenancePage: true
+  # Shared settings for the init/update hook Jobs
+  hooks:
+    # Number of retries for the hook Job before it is marked failed
+    backoffLimit: 1
+    # Auto-clean finished hook Jobs after this many seconds
+    ttlSecondsAfterFinished: 86400
+    # init: block on the DB host:port (TCP) before running `odoo -i`
+    waitForDb: true
+    # Image used by the update hook to scale the deployments down
+    kubectlImage: "alpine/kubectl:1.36.1"
   server_wide_modules: base,web
   # admin_passwd: managed by external secrets
   proxy_mode: "True"
@@ -254,11 +276,11 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 # Additional environment variables for the Odoo container
-# Also injected into the init-db-odoo init container when odoo.init.enabled is true
+# Also injected into the init/update hook Jobs (odoo.init / odoo.update)
 # extraEnv:
 
 # Additional environment variables from secrets or configmaps
-# Also injected into the init-db-odoo init container when odoo.init.enabled is true
+# Also injected into the init/update hook Jobs (odoo.init / odoo.update)
 # extraEnvFrom:
 
 # Extra init containers


### PR DESCRIPTION
Move database init and update out of the main deployment into Helm hook Jobs (templates/hooks/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm hook–based DB init/update Jobs (pre-install/pre-upgrade), hook-scoped RBAC, reusable hook templates, and hook-scoped copies of odoo.conf/ExternalSecret
  * Optional maintenance page served via the existing nginx Service while app is scaled to 0
  * Bundled PostgreSQL can be run as a pre-install hook for local/dev

* **Documentation**
  * Expanded DB lifecycle, hook behavior/ordering, maintenance routing, upgrade/migration notes, and local test instructions

* **Configuration**
  * Chart bumped to 1.0.0-beta; added odoo.hooks settings and odoo.update now defaults to false
<!-- end of auto-generated comment: release notes by coderabbit.ai -->