### PR TITLE
feat: make external-secrets remoteRef.property names configurable

### DIFF
--- a/templates/externalsecrets.yaml
+++ b/templates/externalsecrets.yaml
@@ -24,11 +24,11 @@ spec:
   - secretKey: postgresql-password
     remoteRef:
       key: {{ .Values.externalsecrets.postgresqlKey }}
-      property: postgresql-password
+      property: {{ .Values.externalsecrets.properties.postgresql.password | default "postgresql-password" }}
   - secretKey: postgresql-admin-password
     remoteRef:
       key: {{ .Values.externalsecrets.postgresqlKey }}
-      property: postgresql-admin-password
+      property: {{ .Values.externalsecrets.properties.postgresql.adminPassword | default "postgresql-admin-password" }}
 ---
 {{- end }}
 {{- $odooConf := include "..odooConf" (dict "Values" .Values "dbHost" (include "..dbHost" .) "dbPort" (include "..dbPort" .) "dbName" (include "..dbName" .) "dbUser" (include "..dbUser" .) "dbPassword" "{{ .postgresqlPassword }}" "adminPasswd" "{{ .odooAdminPasswd }}") -}}
@@ -54,11 +54,11 @@ spec:
   - secretKey: postgresqlPassword
     remoteRef:
       key: {{ .Values.externalsecrets.odooKey }}
-      property: postgresql-password
+      property: {{ .Values.externalsecrets.properties.odoo.postgresqlPassword | default "postgresql-password" }}
   - secretKey: odooAdminPasswd
     remoteRef:
       key: {{ .Values.externalsecrets.odooKey }}
-      property: odoo-admin-passwd
+      property: {{ .Values.externalsecrets.properties.odoo.adminPasswd | default "odoo-admin-passwd" }}
 {{- if or .Values.odoo.init.enabled .Values.odoo.update.enabled }}
 ---
 # Hook copy for the init/update Jobs. Rendered as a pre-install/pre-upgrade hook so
@@ -91,10 +91,10 @@ spec:
   - secretKey: postgresqlPassword
     remoteRef:
       key: {{ .Values.externalsecrets.odooKey }}
-      property: postgresql-password
+      property: {{ .Values.externalsecrets.properties.odoo.postgresqlPassword | default "postgresql-password" }}
   - secretKey: odooAdminPasswd
     remoteRef:
       key: {{ .Values.externalsecrets.odooKey }}
-      property: odoo-admin-passwd
+      property: {{ .Values.externalsecrets.properties.odoo.adminPasswd | default "odoo-admin-passwd" }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -259,6 +259,15 @@ externalsecrets:
     name: vault-backend
   postgresqlKey:
   odooKey:
+  # Remote property names looked up inside the Vault keys above. Override these
+  # to match your backend's secret layout.
+  properties:
+    postgresql:                          # properties inside postgresqlKey
+      password: postgresql-password
+      adminPassword: postgresql-admin-password
+    odoo:                                # properties inside odooKey
+      postgresqlPassword: postgresql-password
+      adminPasswd: odoo-admin-passwd
 
 persistence:
   enabled: false


### PR DESCRIPTION
The externalsecrets path hardcoded the Vault property names looked up inside postgresqlKey/odooKey. Different backends use different property naming, so expose them via externalsecrets.properties.{postgresql,odoo} with the current names as defaults (| default), keeping existing installs unaffected. Covers the postgres secret, the odoo-conf secret, and its pre-install hook copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL and Odoo ExternalSecret property names are now configurable through Helm values, providing you with flexibility in mapping Vault keys according to your specific requirements.
  * Custom property name overrides are supported for password and configuration secrets, with automatic fallback to previously hardcoded default names ensuring backward compatibility with existing deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->