### PR TITLE
feat: add scheduled rollout-restart CronJob

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,12 @@ When `maintenance.enabled: true`, the chart:
 
 The update/re-init hooks reuse this same maintenance nginx (config/HTML ConfigMaps) but bring up their own `pre-upgrade` hook copy of the maintenance Deployment (`hooks/maintenance-hook.yaml`, rendered when `update.enabled` **or** `init.enabled`, with `maintenancePage` + `ingress.enabled`). Crucially, that pod carries the chart's `selectorLabels` and a `nginx-http` port, so the existing `<fullname>-nginx` Service routes to it while Odoo is scaled to 0 — **the ingress is never modified** (an earlier `kubectl patch` approach was abandoned because Helm's 3-way merge does not revert out-of-band ingress edits when the rendered ingress manifest is unchanged). The hook is torn down once the upgrade hooks succeed, and the Service routes back to Odoo.
 
+### Scheduled rollout restart
+
+When `rolloutRestart.enabled: true`, `templates/cronjob-rollout-restart.yaml` renders a **CronJob** (`<fullname>-rollout-restart`) plus its own dedicated **ServiceAccount/Role/RoleBinding** (also `<fullname>-rollout-restart`). On its schedule the Job runs `kubectl rollout restart` + `kubectl rollout status` over a list of target deployments. These are **normal** (non-hook) resources — unlike the init/update hooks, the CronJob runs independently of install/upgrade.
+
+The dedicated RBAC is deliberate: the chart's main ServiceAccount mounts no API token (`automountServiceAccountToken: false`), and the `<fullname>-hook` RBAC is hook-scoped and lacks the `watch` verb that `kubectl rollout status` needs. The Role grants `get`/`list`/`watch`/`patch` on `apps/deployments` in the release namespace; the pod sets `automountServiceAccountToken: true`. Image defaults to `odoo.hooks.kubectlImage`, securityContext reuses the chart's pod/container contexts (alpine/kubectl runs fine as uid 100). **Default targets** (empty `rolloutRestart.targets`): the main Odoo deployment `<fullname>`, plus `<fullname>-cron` when `cron.enabled`; an explicit `targets` list overrides this.
+
 ### Health Checks
 
 Both liveness and readiness probes for Odoo hit `/web/health` on the Odoo HTTP port. Liveness has a 120s initial delay; readiness has 30s. The Nginx sidecar probes hit `/healthz` on port 80, which returns 200 directly without proxying to Odoo.
@@ -138,6 +144,7 @@ Connection resolution lives in the `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`
 | `templates/configmap.yaml` | Nginx config and maintenance page HTML |
 | `templates/externalsecrets.yaml` | Vault/external-secrets integration |
 | `templates/hooks/` | Init / update hook Jobs (both `pre-install,pre-upgrade`; init weight `0` < update weight `10`), RBAC, maintenance-page hook |
+| `templates/cronjob-rollout-restart.yaml` | Optional scheduled `kubectl rollout restart` CronJob + its dedicated `<fullname>-rollout-restart` RBAC (gated on `rolloutRestart.enabled`) |
 | `test/local.yaml` | Development overrides (ingress enabled, `odoo.local` hostname) |
 
 ## CI/CD

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo

--- a/README.md
+++ b/README.md
@@ -146,6 +146,28 @@ without touching the ingress.
 > (`helm.sh/hook: pre-install`, weight below `0`) — see `test/local.yaml`. Production
 > should use an external database (`postgresql.enabled: false` + `externalDatabase.*`).
 
+### Scheduled rollout restart (`rolloutRestart`)
+
+Optionally schedule a periodic `kubectl rollout restart` to recycle the Odoo pods
+(e.g. to clear leaked memory or pick up a freshly pulled image tag). When enabled, the
+chart renders a `CronJob` plus a dedicated `ServiceAccount`/`Role`/`RoleBinding`
+(`<release>-rollout-restart`) scoped to `get`/`list`/`watch`/`patch` on deployments in
+the release namespace.
+
+```yaml
+rolloutRestart:
+  enabled: true
+  schedule: "0 3 * * 0"   # weekly, Sunday 03:00 (cluster timezone / UTC)
+  # targets: []           # default: <release> + <release>-cron (when cron.enabled)
+```
+
+On each run it executes `kubectl rollout restart` followed by `kubectl rollout status`
+for every target deployment. When `targets` is empty (the default) it restarts the main
+Odoo deployment and, if `cron.enabled`, the cron deployment too; set `targets` to an
+explicit list of deployment names to override. `concurrencyPolicy: Forbid` prevents
+overlapping runs. The kubectl image defaults to `odoo.hooks.kubectlImage` and can be
+overridden via `rolloutRestart.image`.
+
 ## Production readiness checklist
 
 The chart ships safe-by-default security settings (non-root containers, dropped

--- a/templates/cronjob-rollout-restart.yaml
+++ b/templates/cronjob-rollout-restart.yaml
@@ -1,0 +1,112 @@
+{{- if .Values.rolloutRestart.enabled }}
+{{- $fullName := include "..fullname" . -}}
+{{- $targets := .Values.rolloutRestart.targets -}}
+{{- if not $targets -}}
+{{- $targets = list $fullName -}}
+{{- if .Values.cron.enabled -}}
+{{- $targets = append $targets (printf "%s-cron" $fullName) -}}
+{{- end -}}
+{{- end -}}
+---
+# RBAC for the rollout-restart CronJob: a dedicated ServiceAccount/Role/RoleBinding
+# (not the chart's main SA, which mounts no token, nor the hook-scoped <fullname>-hook
+# RBAC) granting just enough to `kubectl rollout restart` (patch) and `kubectl rollout
+# status` (get/list/watch) the target deployments in this namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-rollout-restart
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-restart
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-rollout-restart
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-restart
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-rollout-restart
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-restart
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}-rollout-restart
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-rollout-restart
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $fullName }}-rollout-restart
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: rollout-restart
+spec:
+  schedule: {{ .Values.rolloutRestart.schedule | quote }}
+  concurrencyPolicy: {{ .Values.rolloutRestart.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.rolloutRestart.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.rolloutRestart.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.rolloutRestart.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.rolloutRestart.activeDeadlineSeconds }}
+      template:
+        metadata:
+          labels:
+            {{- include "..selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: rollout-restart
+        spec:
+          serviceAccountName: {{ $fullName }}-rollout-restart
+          automountServiceAccountToken: true
+          restartPolicy: {{ .Values.rolloutRestart.restartPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.pullSecret }}
+          imagePullSecrets:
+            - name: {{ .Values.image.pullSecret }}
+          {{- end }}
+          containers:
+            - name: kubectl
+              image: "{{ .Values.rolloutRestart.image | default .Values.odoo.hooks.kubectlImage }}"
+              imagePullPolicy: {{ .Values.rolloutRestart.imagePullPolicy }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  for d in {{ $targets | join " " }}; do
+                    echo "restarting deployment/$d"
+                    kubectl rollout restart "deployment/$d"
+                    kubectl rollout status "deployment/$d" --timeout={{ .Values.rolloutRestart.timeout }}
+                  done
+              resources:
+                {{- toYaml .Values.rolloutRestart.resources | nindent 16 }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -176,6 +176,33 @@ cron:
     failureThreshold: 6
     successThreshold: 1
 
+# Scheduled deployment rollout restart (optional).
+# Renders a CronJob (+ its own ServiceAccount/Role/RoleBinding,
+# <fullname>-rollout-restart) that runs `kubectl rollout restart` + `kubectl
+# rollout status` against the Odoo (and cron) deployment(s) on a schedule, to
+# periodically recycle the pods. The Role grants get/list/watch/patch on
+# deployments in the release namespace.
+rolloutRestart:
+  enabled: false
+  # Cron schedule (cluster timezone / UTC). Default: weekly, Sunday 03:00.
+  schedule: "0 3 * * 0"
+  # Deployments to restart. When empty, defaults to the main Odoo deployment
+  # (<fullname>) plus <fullname>-cron when cron.enabled. Set explicit names to override.
+  targets: []
+  # Image used to run kubectl. Defaults to odoo.hooks.kubectlImage.
+  image: ""
+  imagePullPolicy: IfNotPresent
+  # Timeout passed to `kubectl rollout status`.
+  timeout: 300s
+  # Forbid overlapping runs.
+  concurrencyPolicy: Forbid
+  backoffLimit: 2
+  activeDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  restartPolicy: Never
+  resources: {}
+
 # Connection settings for an EXTERNAL PostgreSQL database.
 # Used ONLY when postgresql.enabled is false. When the bundled chart is
 # enabled, connection settings come from the postgresql.* section below instead.


### PR DESCRIPTION
Add an opt-in CronJob (rolloutRestart.enabled) that periodically runs `kubectl rollout restart` + `kubectl rollout status` against the Odoo (and cron) deployment(s), bringing the previously hand-written per-env manifest into the chart.

- New templates/cronjob-rollout-restart.yaml renders a dedicated ServiceAccount/Role/RoleBinding (<fullname>-rollout-restart, granting get/list/watch/patch on deployments) plus the CronJob. Normal (non-hook) resources, independent of install/upgrade.
- Default targets: main Odoo deployment, plus <fullname>-cron when cron.enabled; overridable via rolloutRestart.targets.
- kubectl image defaults to odoo.hooks.kubectlImage; reuses the chart's pod/container securityContext.
- Document in README.md and CLAUDE.md; bump chart to 1.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional scheduled deployment restart functionality that automatically triggers rolling restarts on a configurable schedule.

* **Chores**
  * Updated Helm chart version to 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->