### PR TITLE
fix: force X-Forwarded-Proto https in nginx location blocks

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
       }
     
@@ -45,7 +45,7 @@ data:
         proxy_pass http://odoo;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Real-IP $remote_addr;
       }
       gzip_types text/css text/scss text/plain text/xml application/xml application/json application/javascript;


### PR DESCRIPTION
Fixes #26

## Problem

When Odoo runs behind a TLS-terminating ingress, the nginx sidecar's per-`location` `proxy_set_header X-Forwarded-Proto $scheme;` overrides the server-level `proxy_set_header X-Forwarded-Proto https;`.

nginx inherits `proxy_set_header` into a `location` **only** when that location defines none of its own — both `/websocket` and `/` define their own, so the server-level `https` is never inherited. Since the sidecar listens on plain HTTP `:80`, `$scheme` is always `http`, so Odoo (`proxy_mode = true`) receives `X-Forwarded-Proto: http` and generates `http://` URLs.

This breaks external-IdP OAuth (Entra ID / Azure AD), whose redirect URIs require `https://`, plus any request-derived URL.

## Fix

Hardcode `https` in both location blocks (`/websocket` and `/`). This is consistent with the chart's existing TLS-always assumption — the server block already hardcodes `X-Forwarded-Proto https`, `X-Forwarded-SSL on`, and `X-Forwarded-Protocol ssl`.

```diff
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
```

## Verification

- `helm lint .` and `helm lint -f test/local.yaml .` — both pass.
- Rendered `-nginx-conf` ConfigMap shows `X-Forwarded-Proto https;` in both location blocks; no `$scheme` remains.

No chart version bump (1.2.0 is not released yet, so this folds into the current unreleased version).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated protocol forwarding configuration to ensure HTTPS is consistently specified in proxy headers for websocket and standard web traffic routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->