### PR TITLE
docs: warn (don't disable) when maintenance mode + init/update hooks are both enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ without touching the ingress.
 > scale-to-0 migration runs on every `helm upgrade`.
 
 > [!NOTE]
+> **Maintenance mode does not disable these hooks.** `maintenance.enabled: true` only
+> scales Odoo/cron to 0 and serves the maintenance page — the `init`/`update` Jobs still
+> run on the next `helm install`/`helm upgrade`. This is intentional: you can migrate
+> behind the maintenance page (set `maintenance.enabled: true`, then upgrade with
+> `odoo.update.enabled: true`, then reopen). If you enter maintenance for something that
+> must **not** touch the DB (e.g. a restore), make sure `odoo.init.enabled` and
+> `odoo.update.enabled` are `false`. When both maintenance and a hook are enabled,
+> `helm install`/`helm upgrade` prints a warning in its notes.
+
+> [!NOTE]
 > **Bundled PostgreSQL + hooks:** Helm cannot deploy a subchart before the parent's
 > `pre-install` hooks, so `postgresql.enabled: true` is not up when the Jobs run. For
 > dev/test, run PostgreSQL as a pre-install hook via `postgresql.commonAnnotations`

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -25,3 +25,12 @@
 WARNING: cron.enabled=true but you are using an externally-managed secret.
 Make sure your odoo.conf contains "max_cron_threads = 0" to disable cron on the main instance.
 {{- end }}
+{{- if and .Values.maintenance.enabled (or .Values.odoo.init.enabled .Values.odoo.update.enabled) }}
+
+WARNING: maintenance.enabled=true does NOT disable the init/update hook Jobs.
+{{- if .Values.odoo.init.enabled }} odoo.init.enabled=true will still run `odoo -i` on this install/upgrade.{{- end }}
+{{- if .Values.odoo.update.enabled }} odoo.update.enabled=true will still run `odoo -u` on this upgrade.{{- end }}
+If you are migrating behind the maintenance page, this is expected. If you only meant to
+take the site offline (e.g. for a DB restore), set odoo.init.enabled=false and
+odoo.update.enabled=false so the database is not touched.
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -442,6 +442,9 @@ tolerations: []
 affinity: {}
 
 # Enable maintenance mode
+# NOTE: this only scales Odoo/cron to 0 and shows the maintenance page. It does NOT
+# disable the odoo.init/odoo.update hook Jobs — those still run on install/upgrade (so
+# you can migrate behind the maintenance page). For a DB restore, keep those flags false.
 maintenance:
   enabled: false
   ## You can add a signature to the maintenance page


### PR DESCRIPTION
## Context

**Question raised:** In maintenance mode, if `odoo.init.enabled` or `odoo.update.enabled` are true, the hook Jobs still run. Should maintenance mode disable them?

**Decision:** No — keep them independent.

- `maintenance.enabled` is a *steady-state* control (pins Odoo/cron to `replicas: 0`, swaps the ingress to the persistent maintenance page).
- `init`/`update` are *one-shot* `pre-install,pre-upgrade` hook Jobs that scale Odoo/cron to 0 themselves, run `odoo -i`/`odoo -u --stop-after-init`, then let Helm restore the deployments.

There is no resource conflict today: the transient hook maintenance page already gates on `not .Values.maintenance.enabled`, and the two maintenance pods use different port names/Services (no double-routing). The combination is in fact the intended **migrate-behind-maintenance** workflow (enter maintenance → upgrade with `update.enabled=true` → reopen). Auto-disabling would break that workflow and make an explicit `update.enabled=true` a silent no-op.

Instead: keep the behavior, **warn** when both are set, and **document** the interplay.

## Changes

- **`templates/NOTES.txt`** — conditional `WARNING` (reusing the file's existing pattern) that fires only when `maintenance.enabled` **and** (`init.enabled` **or** `update.enabled`) are set, naming the active hook (`odoo -i` / `odoo -u`).
- **`README.md`** — `[!NOTE]` in the *Database initialization and updates* section clarifying maintenance does not disable the hooks.
- **`values.yaml`** — comment on `maintenance.enabled` to the same effect.

Docs/warning only — no `Chart.yaml` version bump.

## Verification

- `helm lint` → passes.
- Rendered the exact conditional as sentinels (NOTES only render on a real install; no cluster available) and confirmed the gating against chart defaults:
  - maintenance only → no warning
  - hook only (no maintenance) → no warning
  - maintenance + init → warning with `odoo -i`
  - maintenance + update → warning with `odoo -u`