### PR TITLE
feat: render identity/routing value fields through tpl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,10 @@ Three separate services expose different ports:
 - `odoo-odoo` (ClusterIP :8069) — internal Odoo HTTP
 - `odoo-odoo-longpolling` (ClusterIP :8072) — WebSocket/chat
 
+### Templated values (`tpl`)
+
+A set of identity/routing value fields is rendered through `tpl` (context `$`), so a value may embed `{{ .Values.* }}` expressions referencing other values (e.g. `fullnameOverride: "{{ .Values.instance_id }}"`) — designed for an ArgoCD `ApplicationSet` that merges a shared defaults file with per-instance `values.yaml`. Rendered fields: `..name`/`..fullname` (`nameOverride`/`fullnameOverride`), the `..dbHost`/`..dbName`/`..dbUser` helpers (`externalDatabase.host`/`.name`/`.user` + `postgresql.auth.database`/`.username`), `externalsecrets.odooKey`/`postgresqlKey`/`secretStoreRef.name`, and ingress `className`/`hosts[].host`/`paths[].path`/`tls[].secretName`/`tls[].hosts[]`. **Never** `tpl`-rendered: any password (`..dbPassword`), `..dbPort`, and the `..odooConf` body — the last one carries literal external-secrets placeholders (`{{ .postgresqlPassword }}`, `{{ .odooAdminPasswd }}`) that must reach the operator unrendered. `tpl` on a value with no `{{ }}` returns it unchanged, so existing plain-value installs are unaffected.
+
 ### Configuration and Secrets
 
 Odoo is configured via `odoo.conf` injected as a Kubernetes Secret. Three mutually exclusive approaches:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "..name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- tpl (default .Chart.Name .Values.nameOverride | toString) $ | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -12,9 +12,9 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "..fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- tpl (.Values.fullnameOverride | toString) $ | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := tpl (default .Chart.Name .Values.nameOverride | toString) $ }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -68,12 +68,15 @@ Resolve Odoo's database connection from the right source:
 - external (postgresql.enabled false): credentials come from externalDatabase.*
   ("..dbHost" fails fast if externalDatabase.host is not set).
 These take the root context (they need .Release / .Values).
+The host / name / user are rendered through "tpl", so those values may embed
+{{ .Values.* }} expressions (e.g. externalDatabase.name: "{{ .Values.instance_id }}").
+The password and port are intentionally NOT tpl-rendered (a secret / a number).
 */}}
 {{- define "..dbHost" -}}
 {{- if .Values.postgresql.enabled -}}
 {{- printf "%s-postgresql" .Release.Name -}}
 {{- else -}}
-{{- required "externalDatabase.host is required when postgresql.enabled is false" .Values.externalDatabase.host -}}
+{{- tpl (required "externalDatabase.host is required when postgresql.enabled is false" .Values.externalDatabase.host | toString) $ -}}
 {{- end -}}
 {{- end }}
 
@@ -82,11 +85,11 @@ These take the root context (they need .Release / .Values).
 {{- end }}
 
 {{- define "..dbName" -}}
-{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.database }}{{- else -}}{{ .Values.externalDatabase.name }}{{- end -}}
+{{- if .Values.postgresql.enabled -}}{{ tpl (.Values.postgresql.auth.database | toString) $ }}{{- else -}}{{ tpl (.Values.externalDatabase.name | toString) $ }}{{- end -}}
 {{- end }}
 
 {{- define "..dbUser" -}}
-{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.username }}{{- else -}}{{ .Values.externalDatabase.user }}{{- end -}}
+{{- if .Values.postgresql.enabled -}}{{ tpl (.Values.postgresql.auth.username | toString) $ }}{{- else -}}{{ tpl (.Values.externalDatabase.user | toString) $ }}{{- end -}}
 {{- end }}
 
 {{- define "..dbPassword" -}}

--- a/templates/externalsecrets.yaml
+++ b/templates/externalsecrets.yaml
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   secretStoreRef:
-    name: {{ .Values.externalsecrets.secretStoreRef.name }}
+    name: {{ tpl (.Values.externalsecrets.secretStoreRef.name | toString) $ }}
     kind: SecretStore
   target:
     name: {{ include "..fullname" . }}-postgresql-secret
@@ -23,11 +23,11 @@ spec:
   data:
   - secretKey: postgresql-password
     remoteRef:
-      key: {{ .Values.externalsecrets.postgresqlKey }}
+      key: {{ tpl (.Values.externalsecrets.postgresqlKey | toString) $ }}
       property: {{ .Values.externalsecrets.properties.postgresql.password | default "postgresql-password" }}
   - secretKey: postgresql-admin-password
     remoteRef:
-      key: {{ .Values.externalsecrets.postgresqlKey }}
+      key: {{ tpl (.Values.externalsecrets.postgresqlKey | toString) $ }}
       property: {{ .Values.externalsecrets.properties.postgresql.adminPassword | default "postgresql-admin-password" }}
 ---
 {{- end }}
@@ -38,7 +38,7 @@ metadata:
   name: {{ include "..fullname" . }}-odoo-conf-secret
 spec:
   secretStoreRef:
-    name: {{ .Values.externalsecrets.secretStoreRef.name }}
+    name: {{ tpl (.Values.externalsecrets.secretStoreRef.name | toString) $ }}
     kind: SecretStore
   target:
     name: {{ include "..fullname" . }}-odoo-conf
@@ -53,11 +53,11 @@ spec:
   data:
   - secretKey: postgresqlPassword
     remoteRef:
-      key: {{ .Values.externalsecrets.odooKey }}
+      key: {{ tpl (.Values.externalsecrets.odooKey | toString) $ }}
       property: {{ .Values.externalsecrets.properties.odoo.postgresqlPassword | default "postgresql-password" }}
   - secretKey: odooAdminPasswd
     remoteRef:
-      key: {{ .Values.externalsecrets.odooKey }}
+      key: {{ tpl (.Values.externalsecrets.odooKey | toString) $ }}
       property: {{ .Values.externalsecrets.properties.odoo.adminPasswd | default "odoo-admin-passwd" }}
 {{- if or .Values.odoo.init.enabled .Values.odoo.update.enabled }}
 ---
@@ -75,7 +75,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   secretStoreRef:
-    name: {{ .Values.externalsecrets.secretStoreRef.name }}
+    name: {{ tpl (.Values.externalsecrets.secretStoreRef.name | toString) $ }}
     kind: SecretStore
   target:
     name: {{ include "..fullname" . }}-odoo-conf-hook
@@ -90,11 +90,11 @@ spec:
   data:
   - secretKey: postgresqlPassword
     remoteRef:
-      key: {{ .Values.externalsecrets.odooKey }}
+      key: {{ tpl (.Values.externalsecrets.odooKey | toString) $ }}
       property: {{ .Values.externalsecrets.properties.odoo.postgresqlPassword | default "postgresql-password" }}
   - secretKey: odooAdminPasswd
     remoteRef:
-      key: {{ .Values.externalsecrets.odooKey }}
+      key: {{ tpl (.Values.externalsecrets.odooKey | toString) $ }}
       property: {{ .Values.externalsecrets.properties.odoo.adminPasswd | default "odoo-admin-passwd" }}
 {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -14,25 +14,25 @@ metadata:
   {{- end }}
 spec:
   {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  ingressClassName: {{ tpl (.Values.ingress.className | toString) $ }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl (. | toString) $ | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl (.secretName | toString) $ }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl (.host | toString) $ | quote }}
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ tpl (.path | toString) $ }}
             pathType: {{ .pathType }}
             backend:
               service:


### PR DESCRIPTION
Wrap name, DB-identifier, external-secret-key and ingress value fields with `tpl` so values may embed {{ .Values.* }} expressions referencing other values (e.g. fullnameOverride: "{{ .Values.instance_id }}"), enabling one shared values file to derive per-instance strings from top-level keys.

Rendered: ..name/..fullname (nameOverride/fullnameOverride), ..dbHost/..dbName/..dbUser, externalsecrets odooKey/postgresqlKey/ secretStoreRef.name, and ingress className/host/path/tls.

Not rendered (kept literal): any password, db port, and the odoo.conf body -- the latter carries external-secrets operator placeholders ({{ .postgresqlPassword }}) that must reach the operator unrendered. tpl on a value with no {{ }} returns it unchanged, so plain-value installs are unaffected.

Bump chart 1.2.0 -> 1.3.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Helm template interpolation in more chart values, including release naming, database connection settings, ingress hosts/class, TLS hosts, and selected external secret references.
  * Documented which values can and cannot be templated.

* **Chores**
  * Bumped the chart version to **1.3.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->