### PR TITLE
feat: add optional Prometheus ServiceMonitor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,12 @@ When `rolloutRestart.enabled: true`, `templates/cronjob-rollout-restart.yaml` re
 
 The dedicated RBAC is deliberate: the chart's main ServiceAccount mounts no API token (`automountServiceAccountToken: false`), and the `<fullname>-hook` RBAC is hook-scoped and lacks the `watch` verb that `kubectl rollout status` needs. The Role grants `get`/`list`/`watch`/`patch` on `apps/deployments` in the release namespace; the pod sets `automountServiceAccountToken: true`. Image defaults to `odoo.hooks.kubectlImage`, securityContext reuses the chart's pod/container contexts (alpine/kubectl runs fine as uid 100). **Default targets** (empty `rolloutRestart.targets`): the main Odoo deployment `<fullname>`, plus `<fullname>-cron` when `cron.enabled`; an explicit `targets` list overrides this.
 
+### ServiceMonitor (metrics)
+
+When `serviceMonitor.enabled: true` (default **false**), `templates/servicemonitor.yaml` renders a Prometheus Operator **ServiceMonitor** (`monitoring.coreos.com/v1`, `<fullname>-service-monitor`) that scrapes Odoo metrics. Gated solely on its own `enabled` flag — no CRD-presence guard (same precedent as `externalsecrets.yaml`); requires the Prometheus Operator CRDs and an Odoo endpoint actually serving metrics at `serviceMonitor.path` (e.g. a metrics-exporting Odoo module). The chart only wires the scrape — it adds no metrics endpoint.
+
+The selector uses **positive** `matchLabels` (`..selectorLabels` + `app.kubernetes.io/component: server`) rather than a `component != cron` exclusion. A ServiceMonitor selector matches a Service's **`metadata.labels`**, not its `spec.selector`; the `-odoo`/`-lp-odoo` Services previously carried `component: server` only in their `spec.selector`, so `templates/service.yaml` now also stamps `app.kubernetes.io/component: server` into their `metadata.labels` (mirroring how `cron-service.yaml` stamps `component: cron`). The `odoo-http` endpoint then narrows scraping to the `<fullname>-odoo` Service (`-lp-odoo` exposes `odoo-lp-http`, so it's matched by the selector but skipped by the port name; `-cron` carries `component: cron` and is excluded). Configurable via the Standard-scope `serviceMonitor.*` values: `labels`/`annotations` (the `labels` typically carry the operator's `release:` selector), `port`, `path`, `interval`, `scheme`, `scrapeTimeout`, `relabelings`, `metricRelabelings`.
+
 ### Health Checks
 
 Both liveness and readiness probes for Odoo hit `/web/health` on the Odoo HTTP port. Liveness has a 120s initial delay; readiness has 30s. The Nginx sidecar probes hit `/healthz` on port 80, which returns 200 directly without proxying to Odoo.
@@ -147,6 +153,7 @@ Connection resolution lives in the `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`
 | `templates/secrets.yaml` | Generated `odoo.conf` secret — normal `<fullname>-odoo-conf` + gated hook `<fullname>-odoo-conf-hook` |
 | `templates/configmap.yaml` | Nginx config and maintenance page HTML |
 | `templates/externalsecrets.yaml` | Vault/external-secrets integration |
+| `templates/servicemonitor.yaml` | Optional Prometheus Operator `ServiceMonitor` (gated on `serviceMonitor.enabled`) |
 | `templates/hooks/` | Init / update hook Jobs (both `pre-install,pre-upgrade`; init weight `0` < update weight `10`), RBAC, maintenance-page hook |
 | `templates/cronjob-rollout-restart.yaml` | Optional scheduled `kubectl rollout restart` CronJob + its dedicated `<fullname>-rollout-restart` RBAC (gated on `rolloutRestart.enabled`) |
 | `test/local.yaml` | Development overrides (ingress enabled, `odoo.local` hostname) |

--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ explicit list of deployment names to override. `concurrencyPolicy: Forbid` preve
 overlapping runs. The kubectl image defaults to `odoo.hooks.kubectlImage` and can be
 overridden via `rolloutRestart.image`.
 
+### Prometheus ServiceMonitor (`serviceMonitor`)
+
+Optionally expose Odoo metrics to a Prometheus Operator install (e.g.
+kube-prometheus-stack). When enabled, the chart renders a `ServiceMonitor`
+(`monitoring.coreos.com/v1`) that selects the main Odoo Service
+(`<release>-odoo`, `app.kubernetes.io/component: server`) and scrapes the named
+`odoo-http` port — the cron Service is deliberately excluded.
+
+```yaml
+serviceMonitor:
+  enabled: true
+  labels:
+    release: kube-prometheus-stack   # match your Prometheus serviceMonitorSelector
+  path: /metrics
+  interval: 30s
+```
+
+Requires the Prometheus Operator CRDs to be installed in the cluster, and an Odoo
+endpoint that actually serves metrics at `path` on the scraped port (e.g. a
+metrics-exporting Odoo module) — the chart only wires the scrape, it does not add
+a metrics endpoint. Most operators discover `ServiceMonitor`s by a label
+(commonly `release: <prometheus-release>`); set it via `serviceMonitor.labels`.
+`scrapeTimeout`, `scheme`, `relabelings` and `metricRelabelings` are also
+configurable — see [values.yaml](values.yaml).
+
 ## Production readiness checklist
 
 The chart ships safe-by-default security settings (non-root containers, dropped

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -26,6 +26,7 @@ metadata:
   name: {{ include "..fullname" . }}-odoo
   labels:
     {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
 spec:
   type: ClusterIP
   ports:
@@ -46,6 +47,7 @@ metadata:
   name: {{ include "..fullname" . }}-lp-odoo
   labels:
     {{- include "..labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
 spec:
   type: ClusterIP
   ports:

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "..fullname" . }}-service-monitor
+  labels:
+    {{- include "..labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  # Selects the Odoo server Service (`<fullname>-odoo`, component=server) via its
+  # metadata labels; the `odoo-http` endpoint below narrows scraping to that Service
+  # (the cron Service carries component=cron and is excluded).
+  selector:
+    matchLabels:
+      {{- include "..selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  endpoints:
+    - port: {{ .Values.serviceMonitor.port }}
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      scheme: {{ .Values.serviceMonitor.scheme }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -21,10 +21,10 @@ spec:
       {{- include "..selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: server
   endpoints:
-    - port: {{ .Values.serviceMonitor.port }}
-      path: {{ .Values.serviceMonitor.path }}
-      interval: {{ .Values.serviceMonitor.interval }}
-      scheme: {{ .Values.serviceMonitor.scheme }}
+    - port: {{ .Values.serviceMonitor.port | quote }}
+      path: {{ .Values.serviceMonitor.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scheme: {{ .Values.serviceMonitor.scheme | quote }}
       {{- with .Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -308,6 +308,36 @@ service:
   type: ClusterIP
   port: 80
 
+# Prometheus Operator ServiceMonitor for scraping Odoo metrics.
+# Disabled by default. Requires the Prometheus Operator CRDs
+# (monitoring.coreos.com/v1) to be present in the cluster and an Odoo endpoint
+# that serves metrics at `path` on the named `port` (e.g. a metrics-exporting
+# Odoo module). Selects the `component: server` Odoo Service on `odoo-http`; the
+# cron Service is excluded.
+serviceMonitor:
+  enabled: false
+  # Extra labels for the ServiceMonitor. Prometheus Operator commonly requires a
+  # `release:` label matching its serviceMonitorSelector, e.g.:
+  #   labels:
+  #     release: kube-prometheus-stack
+  labels: {}
+  # Extra annotations for the ServiceMonitor.
+  annotations: {}
+  # Service port NAME to scrape (must match a port on the Odoo Service).
+  port: odoo-http
+  # HTTP path exposing Prometheus metrics.
+  path: /metrics
+  # Scrape interval.
+  interval: 30s
+  # Scrape scheme (http or https).
+  scheme: http
+  # Optional per-scrape timeout (e.g. "10s"). Empty = operator default.
+  scrapeTimeout: ""
+  # Optional Prometheus relabeling applied before scraping.
+  relabelings: []
+  # Optional Prometheus relabeling applied to scraped metrics.
+  metricRelabelings: []
+
 ingress:
   enabled: false
   className: "public"


### PR DESCRIPTION
Render a monitoring.coreos.com/v1 ServiceMonitor gated on serviceMonitor.enabled (default false). It selects the Odoo server Service on the odoo-http port and scrapes /metrics; the cron Service is excluded.

A ServiceMonitor selector matches a Service's metadata labels, where component: server did not previously exist (it lived only in spec.selector), so stamp app.kubernetes.io/component: server into the -odoo/-lp-odoo Service metadata labels too (mirrors cron-service.yaml's component: cron). Metadata labels are mutable and do not affect routing.

Standard-scope configurability: labels/annotations, port, path, interval, scheme, scrapeTimeout, relabelings, metricRelabelings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Prometheus ServiceMonitor support for scraping Odoo metrics, configurable via interval, scheme, timeout, labels/annotations, and relabeling rules.
  * Updated monitoring service selection to target only the server component.
* **Documentation**
  * Expanded the README and chart notes with “Prometheus ServiceMonitor” setup/config examples and guidance on required Prometheus Operator CRDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->