### PR TITLE
Feat/cloudpirates postgres

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,4 +19,3 @@ jobs:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.COMMON_MATTERMOST_WEBHOOK_URL }}
           APP_ID: ${{ secrets.APP_ID }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-          HELM_DEPENDENCIES: bitnami,https://charts.bitnami.com/bitnami

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ helm lint -f test/local.yaml .
 # Render templates (dry-run)
 helm template odoo . -f test/local.yaml --namespace odoo
 
-# Update dependencies (PostgreSQL from bitnami)
+# Update dependencies (PostgreSQL from CloudPirates)
 helm dep up
 
 # Deploy to a local cluster
@@ -95,7 +95,7 @@ need is itself provisioned as a pre-install hook; a pod that mounts a not-yet-cr
     the Job's mount retries until it lands. (Helm's hook wait only blocks on Pods/Jobs, not CR status, so this
     relies on the operator syncing within `--timeout`.)
 - **Bundled PostgreSQL** — Helm cannot deploy a subchart before the parent's pre-install hooks, so the bundled
-  bitnami Postgres (`postgresql.enabled: true`) is not up when the hooks run. To use it with the hooks (dev/test),
+  Postgres (`postgresql.enabled: true`) is not up when the hooks run. To use it with the hooks (dev/test),
   run Postgres itself as a pre-install hook via `postgresql.commonAnnotations` (`helm.sh/hook: pre-install`,
   weight below `0`) — see `test/local.yaml`. Production should use an external DB. The Jobs' DB connection
   resolves through the `..dbHost`/`..dbPort`/… helpers.
@@ -140,7 +140,7 @@ Both liveness and readiness probes for Odoo hit `/web/health` on the Odoo HTTP p
 
 Database config is split into two clearly-scoped sections, with `postgresql.enabled` selecting which one Odoo reads:
 
-- `postgresql.*` — the **bundled** bitnami subchart (OCI registry), used when `postgresql.enabled: true` (dev/test). Odoo's connection comes from `postgresql.auth.*`, the host is auto-derived as `<release>-postgresql`, port `5432`. The `global.security.allowInsecureImages: true` setting is required due to the bitnami legacy repo. Bundled credentials are bitnami-native (inline `auth.password`/`auth.postgresPassword` or `auth.existingSecret`).
+- `postgresql.*` — the **bundled** [CloudPirates `postgres`](https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres) subchart (OCI registry, official `docker.io/postgres` image), used when `postgresql.enabled: true` (dev/test). Aliased to `postgresql` in `Chart.yaml`, so the values key and the `<release>-postgresql` resource names are preserved. Odoo's connection comes from `postgresql.auth.*`, the host is auto-derived as `<release>-postgresql`, port `5432`. The image tag is pinned to a PostgreSQL **17.x** digest via `postgresql.image.tag`. Credentials: `auth.username`/`.password`/`.database` configure the **superuser** (this chart has no separate `postgresPassword`; the named user is the superuser and gets a same-named DB), or supply the password via `auth.existingSecret` (key `postgres-password`).
 - `externalDatabase.*` — connection settings for an **external** PostgreSQL (e.g., CloudNativePG, recommended for production), used when `postgresql.enabled: false`. `externalDatabase.host` is required in this mode.
 
 Connection resolution lives in the `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`..dbPassword` helpers in `_helpers.tpl`, which switch source based on `postgresql.enabled`.
@@ -165,4 +165,4 @@ Connection resolution lives in the `..dbHost`/`..dbPort`/`..dbName`/`..dbUser`/`
 - **Push / PR**: Runs `helm lint` + test via `IMIO/gha/helm-test-notify@v6`
 - **Release**: Triggered on successful test on tag; publishes to `https://imio.github.io/helm-charts` via `IMIO/gha/helm-release-notify@v6`
 
-Before creating and pushing a git tag, ensure `version` in `Chart.yaml` matches the tag. The release workflow is triggered by tag pushes and builds dependencies (bitnami) and packages the chart automatically.
+Before creating and pushing a git tag, ensure `version` in `Chart.yaml` matches the tag. The release workflow is triggered by tag pushes and builds dependencies (the CloudPirates `postgres` OCI subchart) and packages the chart automatically.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 2.0.0
+version: 3.0.0
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo
@@ -14,8 +14,12 @@ maintainers:
   - name: IMIO
     url: https://github.com/IMIO/
 dependencies:
-  - name: postgresql
+  # CloudPirates community PostgreSQL chart (official docker.io/postgres image).
+  # Aliased to "postgresql" so the parent keeps the postgresql.* values key and the
+  # generated resources stay named <release>-postgresql (Helm sets the aliased
+  # subchart's .Chart.Name to the alias). Bundled DB is DEV/TEST only.
+  - name: postgres
     alias: postgresql
-    version: 14.x.x
-    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 0.19.8
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: postgresql.enabled

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ This [Helm](https://helm.sh/) chart installs `Odoo` in a [Kubernetes](https://ku
 ## Prerequisites
 
 > [!NOTE]
-> For production environments, it is recommended to use [CloudNativePG](https://github.com/cloudnative-pg/cloudnative-pg) for PostgreSQL. The bundled chart is primarily intended for testing and development purposes, do not use it in production. Be also aware of the upcoming changes to the bitnami catalog described in this [issue](https://github.com/bitnami/containers/issues/83267). 
+> For production environments, it is recommended to use [CloudNativePG](https://github.com/cloudnative-pg/cloudnative-pg) for PostgreSQL. The bundled chart is primarily intended for testing and development purposes, do not use it in production.
 
 - Kubernetes cluster 1.25+
 - Helm 3.8.0+
 - PV provisioner support in the underlying infrastructure.
-- Postgres DB (This chart can install a postgresql database based on the bitnami/postgresql chart). We use it for testing purposes.
+- Postgres DB (This chart can install a PostgreSQL database based on the [CloudPirates `postgres`](https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres) chart, pinned to PostgreSQL 17). We use it for testing purposes.
 
 ## Why do we not use the bitnami/odoo chart?
 
@@ -65,12 +65,16 @@ See the [values.yaml](values.yaml) file for more information.
 
 Database configuration is split into two clearly-scoped sections:
 
-- **`postgresql.*`** — configures the **bundled** bitnami PostgreSQL subchart, used
-  only when `postgresql.enabled: true` (intended for dev/test). Odoo's connection is
+- **`postgresql.*`** — configures the **bundled** [CloudPirates `postgres`](https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres)
+  subchart (official `docker.io/postgres` image, pinned to PostgreSQL **17.x** via
+  `postgresql.image.tag`), used only when `postgresql.enabled: true` (intended for
+  dev/test). The subchart is aliased to `postgresql`, so the values key and the
+  `<release-name>-postgresql` resource names are preserved. Odoo's connection is
   taken from `postgresql.auth.*`, the host is auto-derived as `<release-name>-postgresql`
-  and the port is `5432`. Bundled credentials can be set inline via
-  `postgresql.auth.password` / `postgresql.auth.postgresPassword`, or supplied through
-  `postgresql.auth.existingSecret` (bitnami-native).
+  and the port is `5432`. `postgresql.auth.username` / `.password` / `.database`
+  configure the **superuser** (this chart has no separate `postgresPassword`; the named
+  user is the superuser and gets a same-named database), or supply the password through
+  `postgresql.auth.existingSecret` (default key `postgres-password`).
 - **`externalDatabase.*`** — connection settings for an **external** PostgreSQL
   (e.g. CloudNativePG), used only when `postgresql.enabled: false`. `externalDatabase.host`
   is required in this mode (templating fails fast if it is empty).
@@ -251,8 +255,7 @@ things still need explicit configuration for production:
   filestore must be `ReadWriteMany`.
 - [ ] **External database** — set `postgresql.enabled: false` and configure
   `externalDatabase.*` (e.g. [CloudNativePG](https://github.com/cloudnative-pg/cloudnative-pg)).
-  The bundled bitnami PostgreSQL pulls from the deprecated `bitnamilegacy` registry
-  and is dev/test only.
+  The bundled CloudPirates PostgreSQL uses ephemeral storage and is dev/test only.
 - [ ] **Secrets** — use `existingSecret.enabled: true` or `externalsecrets.enabled: true`
   instead of inline `odoo.admin_passwd` / `externalDatabase.password` so credentials
   never live in plaintext values.
@@ -340,6 +343,31 @@ Please read the official [Helm Contribution Guide](https://github.com/helm/chart
 
 ## Upgrading
 
+### To 3.0.0
+
+The **bundled** PostgreSQL subchart was swapped from `bitnami/postgresql` (which moved to the
+unmaintained `bitnamilegacy` Docker Hub namespace) to the maintained
+[CloudPirates `postgres`](https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres)
+chart on the official `docker.io/postgres` image, pinned to **PostgreSQL 17**. This only affects
+`postgresql.enabled: true` (bundled DB, dev/test) — **external-database users
+(`postgresql.enabled: false` + `externalDatabase.*`) are unaffected.**
+
+The new chart is aliased to `postgresql`, so the values key stays `postgresql.*` and the generated
+resource names are unchanged (`<release>-postgresql` Service/Secret, port `5432`) — no connection
+changes are needed. The `postgresql.*` **schema** changed, though:
+
+- **Removed** `postgresql.auth.postgresPassword` — this chart has a single **superuser**.
+  `postgresql.auth.username` / `.password` / `.database` now configure that superuser (Odoo connects
+  as it and gets a same-named database).
+- **Removed** `postgresql.global.security.allowInsecureImages` and `postgresql.image.repository`
+  (bitnami-legacy specifics) — no longer needed.
+- **Added** `postgresql.image.tag`, pinned to a PostgreSQL 17.x digest.
+- **Renamed** `postgresql.primary.persistence` → `postgresql.persistence` (still `enabled: false`,
+  ephemeral, for dev/test).
+
+The bundled DB is ephemeral and dev/test only, so there is no data migration — just re-render with
+the new values. `helm dep up` will pull the new subchart (removing the old bitnami tarball).
+
 ### To 2.0.0
 
 `externalsecrets.properties.odoo.postgresqlPassword` and `.adminPasswd` changed from a bare
@@ -382,7 +410,7 @@ wrong value.
 > - **Before upgrading, delete the old Deployment(s)** — the selector is now immutable:
 >   `kubectl delete deployment <release>-odoo <release>-odoo-cron -n <ns> --ignore-not-found`
 > - **DB connection values moved:** `postgresql.host/port/auth` → `externalDatabase.*` (external DB),
->   while `postgresql.*` now configures only the bundled bitnami subchart.
+>   while `postgresql.*` now configures only the bundled PostgreSQL subchart.
 > - **`odoo.update.enabled` now defaults to `false`** — init/update run as Helm hook Jobs, not in the main pod.
 > - **Containers are non-root by default** (official Odoo image: uid 100 / gid 101) and get a dedicated
 >   ServiceAccount with its token disabled. Custom images with a different user must override
@@ -394,7 +422,7 @@ This is a breaking release. There are three independent migrations to apply to y
 
 The single `postgresql:` section that previously held both the bundled-chart config and
 the database connection settings has been split into two clearly-scoped sections
-(`postgresql.*` for the bundled bitnami subchart, `externalDatabase.*` for an external
+(`postgresql.*` for the bundled PostgreSQL subchart, `externalDatabase.*` for an external
 database). Update your values as follows:
 
 - `postgresql.host` / `postgresql.port` → `externalDatabase.host` / `externalDatabase.port`

--- a/test/local.yaml
+++ b/test/local.yaml
@@ -106,8 +106,9 @@ externalDatabase:
   user: odoo
   password: mySecuredPassword
 
-# Bundled bitnami PostgreSQL for local testing.
-## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+# Bundled CloudPirates PostgreSQL for local testing (image tag pinned to PG 17.x
+# in the base values.yaml, which this file layers on top of).
+## ref: https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres
 postgresql:
   enabled: true
   # The Odoo init/update hooks run at pre-install and wait for the DB. Helm has
@@ -120,15 +121,14 @@ postgresql:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-20"
   auth:
+    # username/password/database configure the SUPERUSER (no separate postgresPassword).
     # Database name should be false if you are using a multi-tenant setup
     # In this case, we are using the dbfilter option in the odoo section
     database: odoo
     username: odoo
     password: mySecuredPassword
-    postgresPassword: mySecuredPassword
-  primary:
-    persistence:
-      enabled: false
+  persistence:
+    enabled: false
 
 # Use an existing secret for the Odoo configuration instead of generating one
 existingSecret:
@@ -219,7 +219,7 @@ extraEnv:
     value: "test"
 
 extraEnvFrom:
-  # Bundled bitnami DB self-manages this secret (<release>-postgresql)
+  # Bundled CloudPirates DB self-manages this secret (<release>-postgresql)
   - secretRef:
       name: odoo-postgresql
 

--- a/values.yaml
+++ b/values.yaml
@@ -219,19 +219,13 @@ externalDatabase:
   ## it out of plaintext values.
   password: mySecuredPassword
 
-# Bundled PostgreSQL (bitnami subchart) — DEV/TEST ONLY.
-# Set enabled: false to use an external database (configure externalDatabase above).
-# Passwords can be set inline via auth.password/auth.postgresPassword, OR supplied
-# through auth.existingSecret (bitnami-native).
-#
-# !! DEPRECATION WARNING !!
-# This subchart pulls from the `bitnamilegacy/postgresql` image. In 2025 Bitnami
-# moved its free Docker Hub catalog to a "legacy" namespace that receives no
-# further updates/security patches (and may be removed). Do NOT run this in
-# production — set postgresql.enabled: false and point externalDatabase.* at a
-# maintained PostgreSQL (e.g. CloudNativePG). See
-# https://github.com/bitnami/containers/issues/83267
-## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+# Bundled PostgreSQL (CloudPirates `postgres` subchart) — DEV/TEST ONLY.
+# A maintained community chart running the official docker.io/postgres image,
+# aliased to "postgresql" in Chart.yaml (so this key and the <release>-postgresql
+# resource names are preserved). Set enabled: false to use an external database
+# (configure externalDatabase above). Do NOT run the bundled DB in production —
+# use an external, managed PostgreSQL (e.g. CloudNativePG) instead.
+## ref: https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres
 postgresql:
   enabled: true
   # The Odoo init/update hooks run at pre-install and wait for the DB. Helm has
@@ -243,33 +237,28 @@ postgresql:
   commonAnnotations:
     helm.sh/hook: pre-install
     helm.sh/hook-weight: "-20"
-  global:
-    security:
-      # Required so the bitnami chart accepts the non-bitnami `bitnamilegacy`
-      # image override below. This relaxes the subchart's image verification and
-      # is a deliberate DEV/TEST concession — another reason not to use the
-      # bundled DB in production.
-      allowInsecureImages: true
   image:
-    repository: bitnamilegacy/postgresql
+    # PostgreSQL 17 (latest 17.x), digest-pinned. The CloudPirates chart defaults
+    # to PG 18; we pin the tag to the official postgres:17.x image + its manifest
+    # digest. Bump both together to move to a newer 17.x.
+    tag: "17.10@sha256:ebba4f4de37f08f138f97c1443c987a435e783177afedcc4aaf2da1930fbc37a"
+    imagePullPolicy: IfNotPresent
   auth:
-    # Database name should be set as false if you are using a multi-tenant setup
-    # In this case, we are using the dbfilter option in the odoo section
-    database: odoo
+    # username/password/database configure the SUPERUSER created at init (this
+    # chart has no separate postgresPassword; the named user IS the superuser and
+    # gets a same-named database). Odoo connects as this user.
+    # Set database as false for a multi-tenant setup (dbfilter in the odoo section).
     username: odoo
-    # password: managed by a Kubernetes secret, you could use an existing one
     password: mySecuredPassword
-    # postgresPassword is the superuser (postgres) password
-    postgresPassword: mySecuredPassword
-    # To supply credentials from an existing secret instead of the inline values
-    # above, uncomment and point at your secret:
+    database: odoo
+    # To supply the password from an existing secret instead of the inline value
+    # above (e.g. the externalsecrets bundled secret <fullname>-postgresql-secret),
+    # uncomment and point at it (default key: postgres-password):
     # existingSecret: my-db-secret
     # secretKeys:
     #   adminPasswordKey: postgres-password
-    #   userPasswordKey: password
-  primary:
-    persistence:
-      enabled: false
+  persistence:
+    enabled: false
 
 # Use an existing secret for the Odoo configuration instead of generating one
 existingSecret:
@@ -284,10 +273,14 @@ externalsecrets:
   enabled: false
   secretStoreRef:
     name: vault-backend
-  # Vault key holding the PostgreSQL credentials (DB user password + superuser).
-  # Consumed by the bundled-PostgreSQL secret, and the DEFAULT source for the DB
+  # Vault key holding the PostgreSQL password. It is the DEFAULT source for the DB
   # password written into odoo.conf — so the password lives in Vault ONCE and is
-  # shared with the PostgreSQL secret instead of being duplicated under odooKey.
+  # shared instead of being duplicated under odooKey. It also feeds the bundled
+  # <fullname>-postgresql-secret ExternalSecret; to have the bundled DB consume it,
+  # set postgresql.auth.existingSecret: <fullname>-postgresql-secret and
+  # auth.secretKeys.adminPasswordKey: postgresql-password (the CloudPirates chart
+  # has a single superuser password, so the admin-password entry below is unused
+  # unless you point a credential at it).
   postgresqlKey:
   # Vault key holding Odoo's own secrets (the master admin_passwd).
   odooKey:


### PR DESCRIPTION
 ## Replace bitnami PostgreSQL subchart with CloudPirates `postgres` (PostgreSQL 17)

  ### Why
  The bundled dev/test database used the **bitnami `postgresql`** subchart, which now pulls
  from the **unmaintained `bitnamilegacy`** Docker Hub namespace (no updates/security
  patches) behind `global.security.allowInsecureImages: true`. This swaps it for the
  maintained community chart **[CloudPirates `postgres`](https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres)**,
  which runs the official `docker.io/postgres` image, pinned to **PostgreSQL 17.10** (digest).

  > ⚠️  Bundled DB is **dev/test only** — production should continue to use an external DB
  > (`postgresql.enabled: false` + `externalDatabase.*`, e.g. CloudNativePG).

  ### Key decisions
  - **Kept the `postgresql` values key via a Helm `alias`.** Helm sets the aliased
    subchart's `.Chart.Name` to `postgresql`, so `postgresql.enabled` / `postgresql.auth.*`
    are preserved for consumers (ArgoCD per-instance values) and the generated resources
    stay named `<release>-postgresql` — the `..dbHost`/`..dbPort` helpers are **unchanged**.
  - **Pinned PG 17.x by digest** (`image.tag: "17.10@sha256:ebba4f…"`) on the latest
    maintained chart (`0.19.8`, which otherwise defaults to PG 18), `imagePullPolicy: IfNotPresent`.
  - **Bumped chart to `3.0.0`** (breaking `postgresql.*` schema change; `2.0.0` is released).

  ### Changes
  | File | Change |
  |------|--------|
  | `Chart.yaml` | `version` → **3.0.0**; dependency → `postgres 0.19.8` from `oci://registry-1.docker.io/cloudpirates`, `alias: postgresql` |
  | `values.yaml` | Rewrote the `postgresql:` block to the CloudPirates schema (superuser auth, `image.tag` PG 17 digest, `persistence.enabled: false`); dropped `bitnamilegacy`/`allowInsecureImages`/`postgresPassword`; updated the externalsecrets comment |
  | `test/local.yaml` | Same schema update; removed `postgresPassword`; `primary.persistence` → `persistence`; fixed `extraEnvFrom` comment |
  | `.github/workflows/release.yaml` | Removed the bitnami `HELM_DEPENDENCIES` (OCI needs no `helm repo add`) |
  | `CLAUDE.md`, `README.md` | Updated PostgreSQL sections + added a **"To 3.0.0"** upgrade note |

  `templates/_helpers.tpl` and `templates/externalsecrets.yaml` need **no change** thanks to
  the alias. (`Chart.lock`/`charts/*.tgz` are gitignored — regenerated by `helm dep up` at release.)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded the Helm chart to version 3.0.0.
  - Switched the bundled PostgreSQL service to the CloudPirates PostgreSQL chart using PostgreSQL 17.
  - Simplified bundled database authentication and configuration.

- **Bug Fixes**
  - Improved local and test deployments with disabled database persistence.

- **Documentation**
  - Updated installation, production, external database, secrets, and upgrade guidance.
  - Clarified that the bundled database is intended for development and testing, not production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->