### PR TITLE
feat: propagate extra* blocks to init/update hook Jobs

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: odoo
 description: An opiniated Helm Chart for deploying Odoo
 type: application
-version: 3.0.1
+version: 3.0.2
 appVersion: "18.0"
 sources:
   - https://github.com/odoo/odoo

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -174,10 +174,12 @@ Call with the root context; render under `data:` with `nindent 2`.
 
 {{/*
 Shared spec for the Odoo init/update hook Job containers.
-Renders image, pull policy, the odoo.conf mount and extraEnv/extraEnvFrom — but
-NOT name or command (each Job sets those). Filestore (PVC) is intentionally not
-mounted: the hooks only touch the database, and skipping the RWO volume avoids
-contention with the running Odoo deployment. Call with the root context.
+Renders image, pull policy, the odoo.conf mount, extraVolumeMounts and
+extraEnv/extraEnvFrom — but NOT name or command (each Job sets those). Filestore
+(PVC) is intentionally not mounted: the hooks only touch the database, and
+skipping the RWO volume avoids contention with the running Odoo deployment. The
+extra* blocks mirror the web/cron workloads so values-driven additions (e.g. a
+CA-trust bundle) are present in the hook pods too. Call with the root context.
 */}}
 {{- define "..hookOdooContainer" -}}
 image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -189,6 +191,9 @@ volumeMounts:
     mountPath: /etc/odoo/odoo.conf
     subPath: odoo.conf
     readOnly: true
+{{- with .Values.extraVolumeMounts }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
 {{- if .Values.extraEnv }}
 env:
 {{- toYaml .Values.extraEnv | nindent 2 }}
@@ -200,7 +205,8 @@ envFrom:
 {{- end }}
 
 {{/*
-Volumes for the init/update hook Jobs: the odoo.conf secret. Call with root context.
+Volumes for the init/update hook Jobs: the odoo.conf secret plus any extraVolumes
+(mirroring the web/cron workloads). Call with root context.
 */}}
 {{- define "..hookVolumes" -}}
 - name: {{ include "..fullname" . }}-odoo-conf
@@ -211,6 +217,9 @@ Volumes for the init/update hook Jobs: the odoo.conf secret. Call with root cont
         the runtime <fullname>-odoo-conf is a NORMAL resource, applied only after
         pre-install hooks, so it is not yet available to the Jobs. */}}
     secretName: "{{ include "..fullname" . }}-odoo-conf{{ if not .Values.existingSecret.enabled }}-hook{{ end }}"
+{{- with .Values.extraVolumes }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/templates/hooks/job-init.yaml
+++ b/templates/hooks/job-init.yaml
@@ -40,6 +40,9 @@ spec:
         {{- if .Values.odoo.hooks.waitForDb }}
         {{- include "..hookWaitForDbInitContainer" . | nindent 8 }}
         {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: odoo-init
           {{- include "..hookOdooContainer" . | nindent 10 }}

--- a/templates/hooks/job-update.yaml
+++ b/templates/hooks/job-update.yaml
@@ -44,6 +44,9 @@ spec:
         {{- if .Values.odoo.hooks.waitForDb }}
         {{- include "..hookWaitForDbInitContainer" . | nindent 8 }}
         {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: odoo-update
           {{- include "..hookOdooContainer" . | nindent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -416,6 +416,7 @@ autoscaling:
 # extraEnvFrom:
 
 # Extra init containers
+# Also injected into the init/update hook Jobs (odoo.init / odoo.update)
 # extraInitContainers: []
 
 # Extra sidecar containers to add to the main Odoo pod
@@ -424,9 +425,11 @@ autoscaling:
 # extraContainers: []
 
 # Extra volumes
+# Also injected into the init/update hook Jobs (odoo.init / odoo.update)
 # extraVolumes: []
 
 # Extra volume mounts for the Odoo container
+# Also injected into the init/update hook Jobs (odoo.init / odoo.update)
 # extraVolumeMounts: []
 
 podAnnotations: {}


### PR DESCRIPTION
The init/update hook Jobs previously rendered only extraEnv/extraEnvFrom (via the ..hookOdooContainer helper), not extraInitContainers/extraVolumes/ extraVolumeMounts.

Render the same optional extra* blocks the web Deployment already does, reusing the top-level .Values.* keys (the same keys extraEnv already flows through):
- ..hookOdooContainer: append extraVolumeMounts to the container volumeMounts
- ..hookVolumes: append extraVolumes to the pod volumes
- job-init.yaml / job-update.yaml: append extraInitContainers to initContainers

All blocks stay {{- with }}-guarded, so charts that set nothing render unchanged; web/cron output is byte-identical. No default values changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom init containers in installation and upgrade jobs.
  - Added support for extra volumes and volume mounts in hook jobs.
  - Extended hook jobs to use additional environment configuration.

- **Documentation**
  - Clarified which custom configuration options apply to initialization and upgrade jobs.

- **Chores**
  - Bumped the Helm chart version from 3.0.1 to 3.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->